### PR TITLE
[Team 18-Android] 피드백 반영 및 추가로직

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,9 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions.freeCompilerArgs += ["-Xopt-in=coil.annotation.ExperimentalCoilApi"]
+    }
 }
 
 dependencies {
@@ -62,6 +65,6 @@ dependencies {
     // Navigation
     implementation "androidx.navigation:navigation-compose:2.5.0-alpha02"
 
-    // MainImage
+    // Coil
     implementation 'io.coil-kt:coil-compose:1.3.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,16 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.todo.airbnb">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Airbnb">
+        android:theme="@style/Theme.Airbnb"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/todo/airbnb/common/components/HadleImage.kt
+++ b/app/src/main/java/com/example/todo/airbnb/common/components/HadleImage.kt
@@ -1,0 +1,42 @@
+package com.example.todo.airbnb.common.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import coil.compose.ImagePainter
+import com.example.todo.airbnb.R
+
+@Composable
+fun HandleImageResult(
+    painterState: ImagePainter.State,
+    onEmpty: @Composable (() -> Unit)? = null,
+    onSuccess: @Composable (() -> Unit)? = null,
+    onError: @Composable () -> Unit = { DefaultError() },
+    onLoading: @Composable () -> Unit = { DefaultLoading() },
+) {
+    when (painterState) {
+        is ImagePainter.State.Empty -> onEmpty?.invoke()
+        is ImagePainter.State.Loading -> onLoading()
+        is ImagePainter.State.Success -> onSuccess?.invoke()
+        is ImagePainter.State.Error -> onError()
+    }
+}
+
+@Composable
+fun DefaultLoading() {
+    CircularProgressIndicator()
+}
+
+@Composable
+fun DefaultError() {
+    Image(
+        painter = painterResource(id = R.drawable.ic_error),
+        contentDescription = "Error Image",
+        modifier = Modifier.fillMaxSize(),
+        contentScale = ContentScale.FillBounds
+    )
+}

--- a/app/src/main/java/com/example/todo/airbnb/data/Travel.kt
+++ b/app/src/main/java/com/example/todo/airbnb/data/Travel.kt
@@ -3,5 +3,5 @@ package com.example.todo.airbnb.data
 data class Travel(
     val imageURL: String,
     val name: String,
-    val time: String,
+    val time: String? = null,
 )

--- a/app/src/main/java/com/example/todo/airbnb/data/repository/MainRepositoryImpl.kt
+++ b/app/src/main/java/com/example/todo/airbnb/data/repository/MainRepositoryImpl.kt
@@ -6,22 +6,22 @@ import com.example.todo.airbnb.domain.repository.MainRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class MainRepositoryImpl: MainRepository {
-
-    private val locations = listOf(
-        "양재동, 서초구, 서울특별시",
-        "양재역 사거리, 양재1동",
-        "서울특별시 양재2동 시민의숲앞",
-        "서울특별시 양재2동 양재 IC",
-        "강릉시, 강원도",
-        "대전광역시 서구",
-        "대전광역시 중구",
-        "대전광역시 동구",
-        "경기도 수원시"
-    )
+class MainRepositoryImpl : MainRepository {
 
     private val dummyImage =
         "https://a0.muscache.com/im/pictures/2f13349d-879d-43c6-83e3-8e5679291d53.jpg?im_w=480"
+
+    private val locations = listOf(
+        Travel(dummyImage, "양재동, 서초구, 서울특별시"),
+        Travel(dummyImage, "양재역 사거리, 양재1동"),
+        Travel(dummyImage, "서울특별시 양재2동 시민의숲앞"),
+        Travel(dummyImage, "서울특별시 양재2동 양재 IC"),
+        Travel(dummyImage, "강릉시, 강원도"),
+        Travel(dummyImage, "대전광역시 서구"),
+        Travel(dummyImage, "대전광역시 중구"),
+        Travel(dummyImage, "대전광역시 동구"),
+        Travel(dummyImage, "경기도 수원시")
+    )
 
     private val travelList = listOf(
         Travel(dummyImage, "서울", "차로 30분 거리"),
@@ -45,8 +45,10 @@ class MainRepositoryImpl: MainRepository {
         Accommodations(dummyImage, "독특한 공간")
     )
 
-    override fun getSearchWordList(searchWord: String): Flow<List<String>> = flow {
-        val searchList = locations.filter { it.contains(searchWord) }
+    override fun getSearchWordList(searchWord: String): Flow<List<Travel>> = flow {
+        val searchList = locations.filter {
+            it.name.contains(searchWord)
+        }
         emit(searchList)
     }
 

--- a/app/src/main/java/com/example/todo/airbnb/domain/repository/MainRepository.kt
+++ b/app/src/main/java/com/example/todo/airbnb/domain/repository/MainRepository.kt
@@ -5,7 +5,7 @@ import com.example.todo.airbnb.data.Travel
 import kotlinx.coroutines.flow.Flow
 
 interface MainRepository {
-    fun getSearchWordList(searchWord: String): Flow<List<String>>
+    fun getSearchWordList(searchWord: String): Flow<List<Travel>>
 
     fun getTravelLocations(): Flow<List<Travel>>
 

--- a/app/src/main/java/com/example/todo/airbnb/presentation/main/components/BottomBar.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/main/components/BottomBar.kt
@@ -50,12 +50,6 @@ fun BottomBar(navController: NavController) {
                 selected = currentRoute == item.route,
                 onClick = {
                     navController.navigate(item.route) {
-                        navController.graph.startDestinationRoute?.let { route ->
-                            popUpTo(route) {
-                                saveState = true
-                            }
-                        }
-
                         launchSingleTop = true
                         restoreState = true
                     }

--- a/app/src/main/java/com/example/todo/airbnb/presentation/main/components/MainScreen.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/main/components/MainScreen.kt
@@ -8,25 +8,11 @@ import coil.annotation.ExperimentalCoilApi
 import com.example.todo.airbnb.presentation.search.SearchViewModel
 import com.example.todo.airbnb.presentation.search.SearchWidgetState
 
-@ExperimentalCoilApi
 @Composable
 fun MainScreen(viewModel: SearchViewModel) {
 
     val navController = rememberNavController()
-    val searchWidgetState by viewModel.searchWidgetState
-    val searchTextState by viewModel.searchTextState
     Scaffold(
-        topBar = {
-            MainAppBar(
-                searchWidgetState = searchWidgetState,
-                searchTextState = searchTextState,
-                onTextChange = { viewModel.updateSearchText(newValue = it) },
-                onCloseClicked = { viewModel.updateSearchText(newValue = "") },
-                onSearchClicked = {},
-                onOpenTriggered = { viewModel.updateSearchWidgetState(newValue = SearchWidgetState.OPEN) },
-                onCloseTriggered = { viewModel.updateSearchWidgetState(newValue = SearchWidgetState.CLOSED) },
-            )
-        },
         bottomBar = { BottomBar(navController) }
     ) {
         BottomNavGraph(navController, viewModel)

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/SearchViewModel.kt
@@ -26,8 +26,8 @@ class SearchViewModel(
     private val _searchTextState: MutableState<String> = mutableStateOf(value = "")
     val searchTextState: State<String> = _searchTextState
 
-    private val _searchLocations = MutableStateFlow<List<String>>(emptyList())
-    val searchLocations: StateFlow<List<String>> = _searchLocations.asStateFlow()
+    private val _searchLocations = MutableStateFlow<List<Travel>>(emptyList())
+    val searchLocations: StateFlow<List<Travel>> = _searchLocations.asStateFlow()
 
     private val _travelLocations = MutableStateFlow<List<Travel>>(emptyList())
     val travelLocation: StateFlow<List<Travel>> = _travelLocations.asStateFlow()
@@ -37,7 +37,7 @@ class SearchViewModel(
 
     init {
         getTravelLocations()
-        getSearchWord("양재")
+        getSearchLocations("양재")
         getAccommodations()
     }
 
@@ -47,9 +47,14 @@ class SearchViewModel(
 
     fun updateSearchText(newValue: String) {
         _searchTextState.value = newValue
+        viewModelScope.launch {
+            repository.getSearchWordList(newValue).collect {
+                _searchLocations.value = it
+            }
+        }
     }
 
-    private fun getSearchWord(searchWord: String) {
+    fun getSearchLocations(searchWord: String) {
         viewModelScope.launch {
             repository.getSearchWordList(searchWord).collect {
                 _searchLocations.value = it

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/AccommodationsScreen.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/AccommodationsScreen.kt
@@ -1,6 +1,5 @@
 package com.example.todo.airbnb.presentation.search.components
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
@@ -16,8 +15,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
+import com.example.todo.airbnb.common.components.HandleImageResult
 import com.example.todo.airbnb.presentation.search.SearchViewModel
 
 @Composable
@@ -34,11 +33,9 @@ fun SubTitle2() {
     )
 }
 
-@ExperimentalCoilApi
 @Composable
 fun AccommodationsScreen(viewModel: SearchViewModel) {
     val accommodations = viewModel.accommodations.collectAsState().value
-    Log.d("TAG", "$accommodations")
     Column(
         modifier = Modifier.padding(start = 16.dp, end = 16.dp)
     ) {
@@ -57,7 +54,6 @@ fun AccommodationsScreen(viewModel: SearchViewModel) {
     }
 }
 
-@ExperimentalCoilApi
 @Composable
 private fun LoadImage(imgUrl: String) {
     val painter = rememberImagePainter(
@@ -72,6 +68,5 @@ private fun LoadImage(imgUrl: String) {
             .height(294.dp),
         contentScale = ContentScale.FillBounds
     )
-    val painterState = painter.state
-    handleImage(painterState)
+    HandleImageResult(painterState = painter.state)
 }

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/LoadMainImage.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/LoadMainImage.kt
@@ -20,8 +20,9 @@ import coil.annotation.ExperimentalCoilApi
 import coil.compose.ImagePainter
 import coil.compose.rememberImagePainter
 import com.example.todo.airbnb.R
+import com.example.todo.airbnb.common.components.DefaultError
+import com.example.todo.airbnb.common.components.DefaultLoading
 
-@ExperimentalCoilApi
 @Composable
 fun LoadMainImage() {
     Box(
@@ -40,72 +41,50 @@ fun LoadMainImage() {
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.FillBounds
         )
-        if (painterState is ImagePainter.State.Loading) {
-            CircularProgressIndicator(
-                modifier = Modifier.align(Alignment.Center)
-            )
-        } else if (painterState is ImagePainter.State.Error) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_error),
-                contentDescription = "Error Image",
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.FillBounds
-            )
-        } else if (painterState is ImagePainter.State.Success) {
-            Text(
-                text = "슬기로운\n자연생활",
-                modifier = Modifier
-                    .padding(start = 16.dp, bottom = 279.dp, top = 32.dp, end = 90.dp)
-                    .height(96.dp)
-                    .width(254.dp),
-                style = MaterialTheme.typography.h4,
-                lineHeight = 48.sp,
-                color = Color(0xff010101)
-            )
-            Text(
-                text = "에어비앤비가 엄선한\n위시리스트를 만나보세요",
-                modifier = Modifier
-                    .padding(start = 16.dp, bottom = 225.dp, top = 136.dp, end = 90.dp)
-                    .height(46.dp)
-                    .width(254.dp),
-                style = MaterialTheme.typography.body1,
-                lineHeight = 23.sp,
-                color = Color(0xff010101),
-            )
-            Box(
-                modifier = Modifier
-                    .padding(start = 16.dp, bottom = 165.dp, top = 206.dp, end = 90.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .height(36.dp)
-                    .width(154.dp)
-                    .background(Color(0xff333333)),
-            ) {
+        when (painterState) {
+            is ImagePainter.State.Loading -> DefaultLoading()
+            is ImagePainter.State.Error -> DefaultError()
+            is ImagePainter.State.Success -> {
                 Text(
-                    text = "여행 아이디어 얻기",
-                    style = MaterialTheme.typography.button,
+                    text = "슬기로운\n자연생활",
                     modifier = Modifier
-                        .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
-                        .height(20.dp)
-                        .width(122.dp),
-                    lineHeight = 20.sp,
-                    color = Color(0xffffffff),
+                        .padding(start = 16.dp, bottom = 279.dp, top = 32.dp, end = 90.dp)
+                        .height(96.dp)
+                        .width(254.dp),
+                    style = MaterialTheme.typography.h4,
+                    lineHeight = 48.sp,
+                    color = Color(0xff010101)
                 )
+                Text(
+                    text = "에어비앤비가 엄선한\n위시리스트를 만나보세요",
+                    modifier = Modifier
+                        .padding(start = 16.dp, bottom = 225.dp, top = 136.dp, end = 90.dp)
+                        .height(46.dp)
+                        .width(254.dp),
+                    style = MaterialTheme.typography.body1,
+                    lineHeight = 23.sp,
+                    color = Color(0xff010101),
+                )
+                Box(
+                    modifier = Modifier
+                        .padding(start = 16.dp, bottom = 165.dp, top = 206.dp, end = 90.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .height(36.dp)
+                        .width(154.dp)
+                        .background(Color(0xff333333)),
+                ) {
+                    Text(
+                        text = "여행 아이디어 얻기",
+                        style = MaterialTheme.typography.button,
+                        modifier = Modifier
+                            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+                            .height(20.dp)
+                            .width(122.dp),
+                        lineHeight = 20.sp,
+                        color = Color(0xffffffff),
+                    )
+                }
             }
         }
-    }
-}
-
-@ExperimentalCoilApi
-@Composable
-fun handleImage(painterState: ImagePainter.State) {
-    if (painterState is ImagePainter.State.Loading) {
-        CircularProgressIndicator()
-    } else if (painterState is ImagePainter.State.Error) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_error),
-            contentDescription = "Error Image",
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.FillBounds
-        )
     }
 }

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/SearchScreen.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/SearchScreen.kt
@@ -1,51 +1,93 @@
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import coil.annotation.ExperimentalCoilApi
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.example.todo.airbnb.data.Travel
+import com.example.todo.airbnb.presentation.main.components.MainAppBar
 import com.example.todo.airbnb.presentation.search.SearchViewModel
 import com.example.todo.airbnb.presentation.search.SearchWidgetState
-import com.example.todo.airbnb.presentation.search.components.AccommodationsScreen
-import com.example.todo.airbnb.presentation.search.components.LoadMainImage
-import com.example.todo.airbnb.presentation.search.components.TravelScreen
+import com.example.todo.airbnb.presentation.search.components.*
+import com.example.todo.airbnb.presentation.search.components.navigation.SearchNavGraph
+import com.example.todo.airbnb.presentation.search.components.navigation.SearchScreens
 
-@ExperimentalCoilApi
 @Composable
 fun SearchScreen(viewModel: SearchViewModel) {
+    SearchNavGraph(viewModel)
+}
+
+@Composable
+fun SearchMainScreen(navController: NavController, viewModel: SearchViewModel) {
     val searchWidgetState by viewModel.searchWidgetState
-    when (searchWidgetState) {
-        is SearchWidgetState.CLOSED -> {
-            Column(
-                modifier = Modifier.verticalScroll(rememberScrollState())
-            ) {
-                LoadMainImage()
-                TravelScreen(viewModel = viewModel)
-                // TODO[숙소 리스트]
-                AccommodationsScreen(viewModel = viewModel)
+    val searchTextState by viewModel.searchTextState
+    val travelLocations = viewModel.travelLocation.collectAsState().value
+    val searchLocations = viewModel.searchLocations.collectAsState().value
+    Scaffold(
+        topBar = {
+            MainAppBar(
+                searchWidgetState = searchWidgetState,
+                searchTextState = searchTextState,
+                onTextChange = { viewModel.updateSearchText(newValue = it) },
+                onCloseClicked = { viewModel.updateSearchText(newValue = "") },
+                onSearchClicked = { viewModel.getSearchLocations(searchTextState) },
+                onOpenTriggered = { viewModel.updateSearchWidgetState(newValue = SearchWidgetState.OPEN) },
+                onCloseTriggered = { viewModel.updateSearchWidgetState(newValue = SearchWidgetState.CLOSED) },
+            )
+        }
+    ) {
+        when (searchWidgetState) {
+            is SearchWidgetState.CLOSED -> {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState())
+                ) {
+                    LoadMainImage()
+                    TravelScreen(viewModel = viewModel)
+                    AccommodationsScreen(viewModel = viewModel)
+                }
+            }
+            is SearchWidgetState.OPEN -> {
+                when {
+                    searchTextState.isEmpty() -> SearchList(navController, travelLocations)
+                    else -> SearchList(navController, searchLocations)
+                }
             }
         }
-        is SearchWidgetState.OPEN -> {
-            val locations = viewModel.searchLocations.collectAsState().value
-            LazyColumn {
-                if (!locations.isNullOrEmpty()) {
-                    items(locations) { location ->
-                        Text(
-                            modifier = Modifier.fillMaxSize(),
-                            text = location,
-                            style = MaterialTheme.typography.h6,
-                            color = Color.Black,
-                        )
-                    }
-                }
+    }
+
+}
+
+@Composable
+private fun SearchList(navController: NavController, travelLocations: List<Travel>) {
+    LazyColumn(
+        modifier = Modifier
+            .padding(start = 16.dp, bottom = 60.dp, top = 32.dp, end = 16.dp)
+    ) {
+        if (!travelLocations.isNullOrEmpty()) {
+            item {
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp),
+                    text = "근처의 인기 여행지",
+                    style = MaterialTheme.typography.h6
+                )
+            }
+            items(travelLocations) { location ->
+                Row(
+                    modifier = Modifier
+                        .clickable { navController.navigate(SearchScreens.Date.route) }
+                        .fillMaxWidth()
+                ) { MakeItem(location = location) }
+                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/TopBar.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/TopBar.kt
@@ -49,7 +49,7 @@ fun MainAppBar(
 
 
 @Composable
-fun DefaultAppBar(onSearchClicked: () -> Unit) {
+private fun DefaultAppBar(onSearchClicked: () -> Unit) {
     TopAppBar(
         modifier = Modifier.clickable { onSearchClicked() },
         backgroundColor = Gray,
@@ -67,7 +67,7 @@ fun DefaultAppBar(onSearchClicked: () -> Unit) {
 }
 
 @Composable
-fun SearchAppBar(
+private fun SearchAppBar(
     text: String,
     onTextChange: (String) -> Unit,
     onCloseClicked: () -> Unit,

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/TravelScreen.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/TravelScreen.kt
@@ -1,6 +1,7 @@
 package com.example.todo.airbnb.presentation.search.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -10,23 +11,26 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
+import com.example.todo.airbnb.common.components.HandleImageResult
 import com.example.todo.airbnb.data.Travel
 import com.example.todo.airbnb.presentation.search.SearchViewModel
 
-@ExperimentalCoilApi
 @Composable
 fun TravelScreen(viewModel: SearchViewModel) {
     val scrollState = rememberLazyListState()
     val travelLocations = viewModel.travelLocation.collectAsState().value
 
     Column(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+        modifier = Modifier
+            .padding(start = 16.dp, end = 16.dp)
     ) {
         Text(
             modifier = Modifier
@@ -38,48 +42,51 @@ fun TravelScreen(viewModel: SearchViewModel) {
 
         LazyRow(state = scrollState) {
             itemsIndexed(travelLocations) { index, location ->
-                Column(modifier = Modifier.padding(end = 16.dp)) {
-                    if (index % 2 == 0) {
-                        Row {
-                            LoadImage(location)
-                            Spacer(modifier = Modifier.width(16.dp))
-                            Column {
-                                Text(
-                                    text = location.name,
-                                    style = MaterialTheme.typography.h6
-                                )
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Text(
-                                    text = location.time,
-                                    style = MaterialTheme.typography.body1
-                                )
-                            }
-                        }
-                        if (index + 1 < travelLocations.size) {
-                            Row {
-                                LoadImage(location)
-                                Spacer(modifier = Modifier.width(16.dp))
-                                Column {
-                                    Text(
-                                        text = travelLocations[index + 1].name,
-                                        style = MaterialTheme.typography.h6
-                                    )
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Text(
-                                        text = travelLocations[index + 1].time,
-                                        style = MaterialTheme.typography.body1
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
+                MakeColumn(index, location, travelLocations)
             }
         }
     }
 }
 
-@ExperimentalCoilApi
+@Composable
+private fun MakeColumn(
+    index: Int,
+    location: Travel,
+    travelLocations: List<Travel>,
+) {
+    Column(modifier = Modifier.padding(end = 16.dp)) {
+        if (index % 2 == 0) {
+            Row { MakeItem(location) }
+            if (index + 1 < travelLocations.size) {
+                Row { MakeItem(travelLocations[index + 1]) }
+            }
+        }
+    }
+}
+
+@Composable
+fun MakeItem(location: Travel) {
+    LoadImage(location)
+    Spacer(modifier = Modifier.width(16.dp))
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .height(70.dp)
+    ) {
+        Text(
+            text = location.name,
+            style = MaterialTheme.typography.h6
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        if (location.time != null) {
+            Text(
+                text = location.time,
+                style = MaterialTheme.typography.body1
+            )
+        }
+    }
+}
+
 @Composable
 private fun LoadImage(travel: Travel) {
     val painter = rememberImagePainter(
@@ -94,6 +101,5 @@ private fun LoadImage(travel: Travel) {
             .height(70.dp),
         contentScale = ContentScale.FillBounds
     )
-    val painterState = painter.state
-    handleImage(painterState)
+    HandleImageResult(painterState = painter.state)
 }

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/date/DateScreen.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/date/DateScreen.kt
@@ -1,0 +1,10 @@
+package com.example.todo.airbnb.presentation.search.components.date
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+
+@Composable
+fun DateScreen(navController: NavController) {
+    Text(text = " hihi ")
+}

--- a/app/src/main/java/com/example/todo/airbnb/presentation/search/components/navigation/SearchNavigation.kt
+++ b/app/src/main/java/com/example/todo/airbnb/presentation/search/components/navigation/SearchNavigation.kt
@@ -1,0 +1,34 @@
+package com.example.todo.airbnb.presentation.search.components.navigation
+
+import SearchMainScreen
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.todo.airbnb.presentation.search.SearchViewModel
+import com.example.todo.airbnb.presentation.search.components.date.DateScreen
+
+sealed class SearchScreens(var route: String) {
+    object SearchList : SearchScreens("검색리스트")
+    object Date : SearchScreens("캘린더")
+}
+
+@Composable
+fun SearchNavGraph(viewModel: SearchViewModel) {
+    val navController = rememberNavController()
+    NavHost(
+        navController = navController,
+        startDestination = SearchScreens.SearchList.route
+    ) {
+
+        composable(SearchScreens.SearchList.route) {
+            SearchMainScreen(
+                navController = navController,
+                viewModel = viewModel)
+        }
+
+        composable(SearchScreens.Date.route) {
+            DateScreen(navController = navController)
+        }
+    }
+}


### PR DESCRIPTION
안녕하세요 앨런😀
2번째 피드백을 받게 된 @bn-tw2020 @shncder 입니다. 피드백에 따라 화면 구조를 바꾸는 형태로 진행되었습니다.

바텀 네비게이션에 따라(검색, 위시리스트, 내 예약), 검색에 따라 새로운 네비게이션으로(날짜, 요금, 인원 ..)으로 진행했습니다. 피드백 잘 부탁드리겠습니다.

===========================================================================================   

### 📑 구현 

#### 📮 피드백

- common 폴더 추가로 공통적인 components를 관리

- experimentalCoilApi 어노테이션을 추가하지 않도록 gradle에서 수정

- popUpTo에서 startDestination 추가할 필요가 없어 제거
  - backstack에 쌓아놓고 뒤로가기를 하면되는데, 계속 검색으로만 이동해서 필요없다고 판단

- appBar가 검색탭에 특화되도록 적용

  ```
  MianScreen
  ㄴ SearchScreen
  ㄴㄴ MainAppBar
  ```

  검색탭에 특화되도록 적용하니, 검색 탭에 대한 흐름(날짜 결정, 인원 결정 등)에 따른 커스텀 AppBar 구현이 편해질 것 같습니다.

- 복잡한 로직에 함수화
  - 아이템 레이아웃 등 코드가 복잡해지는 것들은 함수화로 가독성 증가

#### 📮 피드백하면서 추가된 로직

- 검색탭 흐름에 따른 로직을 위해 네비게이션 설정
  - 검색 탭에 흐름에 따라 레이아웃을 수정하게 되면서 자연스럽게 검색탭 네비게이션(날짜, 인원, 요금 ...) 설정 필요해짐
  - 검색리스트 아이템 클릭시 DateScreen으로 이동

|검색 리스트 화면(검색전)|검색 리스트 화면(검색후)|날짜 선택 화면|
|-|-|-|
|<img src="https://user-images.githubusercontent.com/91953080/170621287-4e3b32e6-e269-4839-92b2-90d1749e2db7.png" width="300" height="600">|<img src="https://user-images.githubusercontent.com/91953080/170622023-14d7ad32-e212-46c4-add4-45797d58aeb7.png" width="300" height="600">|<img src="https://user-images.githubusercontent.com/91953080/170621282-e95732f1-ef1e-48d5-b0ff-338ce048c59b.png" width="300" height="600">|

### 🤔 질문사항

- compose 네비게이션을 적용하면서 NavGraph을 설정하는 큰 틀(MainScreen), 각각의 스크린(SearchScreen, WishScreen, ReservationScreen)을 xml 관점으로 바라본다면,

  MainScreen이 액티비티, 각각의 스크린(SearchScreen, WishScreen, ReservationScreen)이 프래그먼트처럼 느껴지는데 이런식으로 개발하는 것이 맞을까요?

  그래서, SearchScreen에서도 SearchNavGraph가 있고, 각각에 맞게 SearchListScreen, DateScreen으로 진행하게 되었습니다.

