### PR TITLE
[Team-16] [Android] [PR-2] 홈 화면 컴포즈로 구현

### DIFF
--- a/Android/app/src/main/java/com/team16/airbnb/ui/HomeFragment.kt
+++ b/Android/app/src/main/java/com/team16/airbnb/ui/HomeFragment.kt
@@ -1,6 +1,7 @@
 package com.team16.airbnb.ui
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -29,13 +30,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import coil.compose.AsyncImage
 import com.team16.airbnb.R
 import com.team16.airbnb.data.NearInfo
 import com.team16.airbnb.data.lastList
 import com.team16.airbnb.data.list
 import com.team16.airbnb.databinding.FragmentHomeBinding
+import com.team16.airbnb.databinding.FragmentSearchBinding
 import com.team16.airbnb.ui.theme.AirbnbTheme
 import com.team16.airbnb.ui.theme.Airbnb_Black
 import com.team16.airbnb.ui.theme.Airbnb_Primary
@@ -43,14 +47,23 @@ import com.team16.airbnb.ui.theme.Off_White
 
 class HomeFragment : Fragment() {
 
-    private val binding: FragmentHomeBinding by lazy {
-        FragmentHomeBinding.inflate(layoutInflater)
-    }
+    private lateinit var binding: FragmentHomeBinding
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        Log.d("AppTest", "HomeFragment/ onCreateView")
+
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_home, container, false)
+        val view = binding.root
+        return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Log.d("AppTest", "HomeFragment/ onViewCreated")
+
         binding.composeViewInHome.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -62,8 +75,10 @@ class HomeFragment : Fragment() {
                 }
             }
         }
-        return binding.root
+
     }
+
+
 
     @Composable
     fun HomeView() {
@@ -84,7 +99,9 @@ class HomeFragment : Fragment() {
             },
             actions = {
                 IconButton(
-                    onClick = { /*TODO*/ }
+                    onClick = {
+                        findNavController().navigate(R.id.action_homeFragment_to_searchFragment)
+                    }
                 ) {
                     Icon(
                         painter = painterResource(
@@ -95,7 +112,7 @@ class HomeFragment : Fragment() {
                     )
                 }
             },
-            backgroundColor = Off_White,
+            backgroundColor = Off_White
         )
     }
 

--- a/Android/app/src/main/java/com/team16/airbnb/ui/HomeFragment.kt
+++ b/Android/app/src/main/java/com/team16/airbnb/ui/HomeFragment.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -53,7 +55,7 @@ class HomeFragment : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
+                    //modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
                     HomeView()
@@ -94,16 +96,17 @@ class HomeFragment : Fragment() {
                 }
             },
             backgroundColor = Off_White,
-            )
+        )
     }
 
     @Composable
     fun NearTripView(info: List<NearInfo>) {
         LazyHorizontalGrid(
-            rows = GridCells.Fixed(2),
             modifier = Modifier
                 .height(200.dp)
-                .fillMaxWidth()
+                //.wrapContentHeight()
+                .fillMaxWidth(),
+            rows = GridCells.Fixed(2)
         ) {
             items(info) { info ->
                 NearDestination(info = info)
@@ -125,19 +128,37 @@ class HomeFragment : Fragment() {
     fun NearDestination(info: NearInfo) {
         Row(
             modifier = Modifier
-                .width(200.dp)
+                .width(220.dp)
+                //.fillMaxWidth(0.3f)
+                .padding(16.dp, 0.dp, 16.dp, 0.dp)
+                .wrapContentHeight()
         ) {
             Box(
-                modifier = Modifier.size(40.dp, 40.dp)
+                modifier = Modifier
+                    .fillMaxWidth(0.35f)
+                    .align(CenterVertically)
+                    .aspectRatio(1 / 1f)
             ) {
                 ImageLoad(image = info.image)
             }
-            
-            Spacer(modifier = Modifier.width(20.dp))
-            Column(modifier = Modifier.size(100.dp, 60.dp)) {
-                Text(text = "${info.name}")
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .align(CenterVertically)
+            ) {
+                Text(
+                    text = "${info.name}",
+                    fontSize = 19.sp,
+                    fontWeight = FontWeight.Bold
+                )
                 Spacer(modifier = Modifier.height(10.dp))
-                Text("${info.distance}")
+                Text(
+                    "${info.distance}",
+                    fontSize = 16.sp
+                )
             }
 
         }
@@ -156,7 +177,8 @@ class HomeFragment : Fragment() {
             Image(
                 painter = painterResource(id = R.drawable.hero_image),
                 contentDescription = "hero_image",
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -173,12 +195,12 @@ class HomeFragment : Fragment() {
                 fontSize = 23.sp
             )
 
-            Spacer(modifier = Modifier.height(60.dp))
+            Spacer(modifier = Modifier.height(5.dp))
 
             NearTripView(info = list)
-            
+
             Spacer(modifier = Modifier.height(32.dp))
-            
+
             Text(
                 text = "어디에서나, 여행은\n살아보는거야",
                 modifier = Modifier
@@ -190,9 +212,9 @@ class HomeFragment : Fragment() {
                 ),
                 fontSize = 23.sp
             )
-            
-            Spacer(modifier = Modifier.height(30.dp))
-            
+
+            Spacer(modifier = Modifier.height(24.dp))
+
             HomeLastView(info = lastList)
         }
     }
@@ -203,8 +225,8 @@ class HomeFragment : Fragment() {
             modifier = Modifier
                 .fillMaxWidth()
                 .height(300.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) { 
+            horizontalArrangement = Arrangement.spacedBy(5.dp)
+        ) {
             items(info) {
                 LastViewItem(info = it)
             }
@@ -216,22 +238,23 @@ class HomeFragment : Fragment() {
         Column(
             modifier = Modifier
                 .wrapContentHeight()
-                .width(200.dp)
+                .width(230.dp)
+                .padding(16.dp, 0.dp)
         ) {
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(242 / 294f),
-                shape = RoundedCornerShape(15),
+                shape = RoundedCornerShape(8),
                 elevation = 30.dp
             ) {
                 ImageLoad(image = info.image)
             }
-            
+
             Spacer(modifier = Modifier.height(10.dp))
-            
+
             Text(text = info.title)
-            
+
         }
     }
 

--- a/Android/app/src/main/java/com/team16/airbnb/ui/search/SearchFragment.kt
+++ b/Android/app/src/main/java/com/team16/airbnb/ui/search/SearchFragment.kt
@@ -1,0 +1,78 @@
+package com.team16.airbnb.ui.search
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import com.team16.airbnb.R
+import com.team16.airbnb.databinding.FragmentSearchBinding
+
+class SearchFragment : Fragment() {
+
+    private lateinit var binding: FragmentSearchBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_search, container, false)
+        val view = binding.root
+        return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setBackButton()
+        setEraseButton()
+        setEditText()
+    }
+
+    private fun setBackButton() {
+        binding.ivBack.setOnClickListener {
+            activity?.onBackPressed()
+        }
+    }
+
+    private fun setEraseButton() {
+        binding.ivEraseText.setOnClickListener {
+            Log.d("AppTest", "erase clicked")
+            binding.etSearch.setText("")
+        }
+    }
+
+    private fun setEditText() {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+
+            }
+
+            override fun afterTextChanged(s: Editable?) {
+                Log.d("AppTest", "text len : ${s.toString().length}")
+                if (s.toString().isNotEmpty()) {
+                    binding.ivEraseText.visibility = View.VISIBLE
+
+                    // 검색어 기준 정보 가져오기
+
+                } else {
+                    binding.ivEraseText.visibility = View.INVISIBLE
+
+                    // 검색어 x 인 경우 리스트 보여주기
+
+                }
+            }
+
+        })
+    }
+
+}

--- a/Android/app/src/main/res/drawable/ic_back.xml
+++ b/Android/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#333333"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.77,3.77l-1.77,-1.77l-10,10l10,10l1.77,-1.77l-8.23,-8.23z"/>
+</vector>

--- a/Android/app/src/main/res/drawable/ic_close.xml
+++ b/Android/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#232222"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/Android/app/src/main/res/layout/fragment_search.xml
+++ b/Android/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@color/airbnb_offWhite"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <View
+                    android:id="@+id/empty_view_1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintWidth_percent="0.044"/>
+
+                <ImageView
+                    android:id="@+id/iv_back"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    app:layout_constraintStart_toEndOf="@id/empty_view_1"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintWidth_percent="0.066"
+                    app:layout_constraintDimensionRatio="1:1"
+                    android:src="@drawable/ic_back"/>
+
+                <View
+                    android:id="@+id/empty_view_2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintWidth_percent="0.044"/>
+
+                <ImageView
+                    android:id="@+id/iv_erase_text"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    app:layout_constraintEnd_toStartOf="@id/empty_view_2"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintWidth_percent="0.066"
+                    app:layout_constraintDimensionRatio="1:1"
+                    android:src="@drawable/ic_close"
+                    android:visibility="invisible"/>
+
+                <EditText
+                    android:id="@+id/et_search"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:inputType="text"
+                    app:layout_constraintStart_toEndOf="@id/iv_back"
+                    app:layout_constraintEnd_toStartOf="@id/iv_erase_text"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginEnd="2dp"
+                    android:background="@null"
+                    android:hint="@string/search_hint"
+                    />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+
+
+
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/Android/app/src/main/res/layout/item_search_area.xml
+++ b/Android/app/src/main/res/layout/item_search_area.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <View
+        android:id="@+id/empty_view_1"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="360:2"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@id/empty_view_2"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="360:2" />
+
+    <View
+        android:id="@+id/empty_view_3"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/empty_view_1"
+        app:layout_constraintBottom_toTopOf="@id/empty_view_2"
+        app:layout_constraintDimensionRatio="360:70"
+        />
+
+    <View
+        android:id="@+id/empty_view_4"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/empty_view_1"
+        app:layout_constraintBottom_toTopOf="@id/empty_view_2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_percent="0.044"
+        />
+
+    <ImageView
+        android:id="@+id/iv_image"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="@id/empty_view_3"
+        app:layout_constraintBottom_toBottomOf="@id/empty_view_3"
+        app:layout_constraintStart_toEndOf="@id/empty_view_4"
+        app:layout_constraintDimensionRatio="1:1"
+        tools:src="@drawable/ic_launcher_background"
+        android:scaleType="fitXY"/>
+
+    <View
+        android:id="@+id/empty_view_5"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="@id/empty_view_3"
+        app:layout_constraintBottom_toBottomOf="@id/empty_view_3"
+        app:layout_constraintStart_toEndOf="@id/iv_image"
+        app:layout_constraintWidth_percent="0.044"
+        />
+    
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_text_area"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toEndOf="@id/empty_view_5"
+        app:layout_constraintTop_toTopOf="@id/empty_view_3"
+        app:layout_constraintBottom_toBottomOf="@id/empty_view_3"
+        app:layout_constraintWidth_percent="0.5">
+
+        <View
+            android:id="@+id/cl_empty_view_1"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintHeight_percent="0.1"
+            />
+
+        <TextView
+            android:id="@+id/tv_area_name"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/cl_empty_view_1"
+            android:gravity="left|center_vertical"
+            app:layout_constraintHeight_percent="0.4"
+            android:autoSizeTextType="uniform"
+            tools:text="서울"
+            android:textStyle="bold"
+            android:textColor="@color/airbnb_Black"/>
+
+        <View
+            android:id="@+id/cl_empty_view_2"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/tv_area_name"
+            app:layout_constraintHeight_percent="0.05"
+            />
+
+        <TextView
+            android:id="@+id/tv_time_info"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/cl_empty_view_2"
+            android:gravity="left|center_vertical"
+            app:layout_constraintHeight_percent="0.33"
+            android:autoSizeTextType="uniform"
+            tools:text="차로 4.5시간 거리"
+            android:textColor="@color/airbnb_Grey3"/>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/app/src/main/res/layout/item_search_description.xml
+++ b/Android/app/src/main/res/layout/item_search_description.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <View
+        android:id="@+id/empty_view_1"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="360:33"/>
+
+    <View
+        android:id="@id/empty_view_2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="@id/empty_view_1"
+        app:layout_constraintTop_toTopOf="@id/empty_view_1"
+        app:layout_constraintBottom_toBottomOf="@id/empty_view_1"
+        app:layout_constraintWidth_percent="0.044"/>
+
+    <TextView
+        android:id="@+id/tv_description"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="@id/empty_view_1"
+        app:layout_constraintBottom_toBottomOf="@id/empty_view_1"
+        app:layout_constraintStart_toEndOf="@id/empty_view_2"
+        app:layout_constraintWidth_percent="0.7"
+        android:autoSizeTextType="uniform"
+        android:text="근처의 인기 여행지"
+        android:textColor="@color/airbnb_Black"
+        android:maxLines="1"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/app/src/main/res/navigation/nav_graph.xml
+++ b/Android/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,11 @@
     <fragment
         android:id="@+id/homeFragment"
         android:name="com.team16.airbnb.ui.HomeFragment"
-        android:label="HomeFragment" />
+        android:label="HomeFragment" >
+        <action
+            android:id="@+id/action_homeFragment_to_searchFragment"
+            app:destination="@id/searchFragment" />
+    </fragment>
     <fragment
         android:id="@+id/myBookFragment"
         android:name="com.team16.airbnb.ui.MyBookFragment"
@@ -16,4 +20,8 @@
         android:id="@+id/wishFragment"
         android:name="com.team16.airbnb.ui.WishFragment"
         android:label="WishFragment" />
+    <fragment
+        android:id="@+id/searchFragment"
+        android:name="com.team16.airbnb.ui.search.SearchFragment"
+        android:label="SearchFragment" />
 </navigation>

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -12,5 +12,6 @@
     <color name="airbnb_Primary">#E84C60</color>
     <color name="airbnb_Grey1">#333333</color>
     <color name="airbnb_Grey3">#828282</color>
+    <color name="airbnb_offWhite">#F5F5F7</color>
 
 </resources>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="label_search">검색</string>
     <string name="label_wish">위시리스트</string>
     <string name="label_my">내 예약</string>
+    <string name="search_hint">어디로 여행하세요?</string>
 </resources>

--- a/Android/app/src/main/res/values/themes.xml
+++ b/Android/app/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/airbnb_offWhite</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/Android/app/src/main/res/values/themes.xml
+++ b/Android/app/src/main/res/values/themes.xml
@@ -12,5 +12,7 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">@color/airbnb_offWhite</item>
         <!-- Customize your theme here. -->
+
+        <item name="colorControlActivated">@color/airbnb_Black</item>
     </style>
 </resources>


### PR DESCRIPTION
안녕하세요 레노 😄 
지난 번 피드백 감사했습니다
화면 이동 뿐만 아니라 각 화면에서 필요한 데이터 및 상태를 퍼니와 함께 고민하고 있습니다

우선 이번에는 홈 첫 화면을 학습 후 모두 컴포즈로 구현을 했습니다

--- 

- 툴바를 나타내기 위해 Scaffold 와 TopAppBar 를 사용했습니다
- 기존의 xml 방식의 리사이클러뷰를 사용해서 데이터 리스트를 나타내는 부분은 LazyRow 와 LazyHorizontalGrid를 사용해 구현했습니다
LazyHorizontalGrid의 경우에는 공식문서의 언어를 영어로 설정하는 경우에 내용이 포함되어 있어 (한글인 경우 x) 찾는데 시간이 조금 소요되었습니다
- Coil 이미지 로딩 라이브러리를 Compose에 맞게 사용해 이미지 처리를 했습니다
- 스크롤 화면을 위해 Column 에 verticalScroll 속성을 부여해 수직 스크롤을 구현했습니다

![compose_demo](https://user-images.githubusercontent.com/69443895/170634248-4440d1dd-e0dc-4556-afc9-542f609b1e4f.gif)

---

< 질문 > 

![image](https://user-images.githubusercontent.com/69443895/170634606-249e1133-e89f-48f2-804b-3263ebc0ce70.png)

- 툴바에서 현재 검색을 할 수 있게 EditText를 배치해서 사용을 하고 있는데 찾아 보니 SearchView라는 요소도 있었습니다
저희가 구현하기 편한 것을 사용하면 될까요? 아니면 더 많이 사용하는 방식이 있을까요?!
<br>

- 달력 관련
![image](https://user-images.githubusercontent.com/69443895/170634765-4223b327-0997-4456-a104-0f151d413ca4.png)

![image](https://user-images.githubusercontent.com/69443895/170634878-39d5eaaa-4bf4-4846-8303-a1f92137fdb8.png)

- 디자인에 나와있는 달력화면을 구현하기 위해 MaterialDesing의 DateRangePicker를 사용해보려 하고 있습니다. (https://material.io/components/date-pickers/android#date-pickers)
DateRangePicker 의 경우 전체 화면을 차지해서 디자인 처럼 화면 하단을 제외한 부분만 차지할 수 있게 크기를 수정하려 했지만 잘 되지 않았습니다, 이미 정해진 스타일이 있어서 그런지 수정이 어려웠습니다..
그래서 다른 외부 캘린더 라이브러리를 사용을 해야할 지 고민을 하고 있는 상황입니다
이런 경우 어떤 방향으로 나가야할 지 조언?을 들어보고 싶습니다!


