### PR TITLE
[team-30] 달력 구현 1주차 PR -2

### DIFF
--- a/airbnb/.eslintrc.js
+++ b/airbnb/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'linebreak-style': 'off',
     '@typescript-eslint/no-var-requires': 'off',
+    'react/jsx-no-constructed-context-values': 'off',
     'react/jsx-filename-extension': [
       2,
       { extensions: ['.js', '.jsx', '.ts', '.tsx'] },

--- a/airbnb/package-lock.json
+++ b/airbnb/package-lock.json
@@ -21,7 +21,6 @@
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
         "@types/styled-components": "^5.1.25",
-        "@types/uuid": "^8.3.4",
         "craco-alias": "^3.0.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -32,6 +31,7 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.25.0",
         "@typescript-eslint/parser": "^5.25.0",
         "eslint": "^8.16.0",
@@ -4344,7 +4344,8 @@
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -20274,7 +20275,8 @@
     "@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/airbnb/package-lock.json
+++ b/airbnb/package-lock.json
@@ -21,13 +21,15 @@
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
         "@types/styled-components": "^5.1.25",
+        "@types/uuid": "^8.3.4",
         "craco-alias": "^3.0.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1",
         "styled-components": "^5.3.5",
         "styled-reset": "^4.4.1",
-        "typescript": "^4.6.4"
+        "typescript": "^4.6.4",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.25.0",
@@ -4338,6 +4340,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -20263,6 +20270,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/airbnb/package.json
+++ b/airbnb/package.json
@@ -16,7 +16,6 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "@types/styled-components": "^5.1.25",
-    "@types/uuid": "^8.3.4",
     "craco-alias": "^3.0.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
@@ -51,6 +50,7 @@
     ]
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "eslint": "^8.16.0",

--- a/airbnb/package.json
+++ b/airbnb/package.json
@@ -16,13 +16,15 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "@types/styled-components": "^5.1.25",
+    "@types/uuid": "^8.3.4",
     "craco-alias": "^3.0.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.1",
-    "typescript": "^4.6.4"
+    "typescript": "^4.6.4",
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "start": "craco start",

--- a/airbnb/src/App.tsx
+++ b/airbnb/src/App.tsx
@@ -1,13 +1,16 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { Home } from './Pages/Home';
 import { theme, GlobalStyle } from './styles';
+import { SearchingProvider } from './Context/Searching';
 
 function App() {
   return (
     <>
       <GlobalStyle />
       <ThemeProvider theme={theme}>
-        <Home />
+        <SearchingProvider>
+          <Home />
+        </SearchingProvider>
       </ThemeProvider>
     </>
   );

--- a/airbnb/src/Component/Schedule/Schedule.tsx
+++ b/airbnb/src/Component/Schedule/Schedule.tsx
@@ -3,36 +3,28 @@ import * as S from './ScheduleStyle';
 
 const WEEKDAY: string[] = ['일', '월', '화', '수', '목', '금', '토'];
 
-const getMonthDate = (year: number, month: number): [number[]] => {
-  let fullDate: number = 32 - new Date(year, month, 32).getDate();
-  let firstDate: number = new Date(year, month, 1).getDay();
-  const isFeburary: number = fullDate % 7;
-  const DateArr: object[] = new Array(isFeburary ? 5 : 4).fill([]);
-  let flag = 1;
+const getMonthDate = (year: number, month: number) => {
+  const fullDate: number = 32 - new Date(year, month, 32).getDate(); // 해달 달이 총 몇일인지
+  const firstDate: number = -new Date(year, month, 1).getDay(); // 1일이 몇요일인지
+  const addDate = fullDate + firstDate;
 
-  // TODO: 리팩토링
-  const result = DateArr.map(week => {
-    for (let i = 0; i < WEEKDAY.length; i += 1) {
-      if (firstDate > 0 || fullDate <= 0) {
-        firstDate -= 1;
-        week = [...week, 0];
-      } else {
-        week = [...week, flag];
-        flag += 1;
-        fullDate -= 1;
-      }
-    }
-    return week;
-  });
-  return result;
+  const firstWeek = new Array(WEEKDAY.length).map((_, idx) => firstDate + idx);
+
+  const currentMonth = Array.from(
+    { length: Math.floor(addDate / WEEKDAY.length) },
+    (_, i) =>
+      firstWeek.map(v => {
+        const day = v + i * 7;
+        return day < 1 || day > fullDate ? null : day;
+      }),
+  );
+  return currentMonth;
 };
 
 export function Schedule(): JSX.Element {
   const testYear = 2022;
   const tesyMonth = 4;
-
   const testFullDate = getMonthDate(testYear, tesyMonth);
-
   return (
     <S.ScheduleWrapper>
       <S.Calendar>
@@ -41,8 +33,11 @@ export function Schedule(): JSX.Element {
             <li key={v4()}>{value}</li>
           ))}
         </S.WeekDay>
-
-        <S.WeekDate>{testFullDate[]}</S.WeekDate>
+        <S.WeekDate>
+          {/* week.map 돌때 {} 감싸고 ul 태그 더해주기 */}
+          {testFullDate.map(week => week.map(day => <li key={v4()}>{day}</li>))}
+        </S.WeekDate>
+        <S.WeekDate>{}</S.WeekDate>
       </S.Calendar>
       <S.Calendar>d</S.Calendar>
     </S.ScheduleWrapper>

--- a/airbnb/src/Component/Schedule/Schedule.tsx
+++ b/airbnb/src/Component/Schedule/Schedule.tsx
@@ -1,0 +1,50 @@
+import { v4 } from 'uuid';
+import * as S from './ScheduleStyle';
+
+const WEEKDAY: string[] = ['일', '월', '화', '수', '목', '금', '토'];
+
+const getMonthDate = (year: number, month: number): [number[]] => {
+  let fullDate: number = 32 - new Date(year, month, 32).getDate();
+  let firstDate: number = new Date(year, month, 1).getDay();
+  const isFeburary: number = fullDate % 7;
+  const DateArr: object[] = new Array(isFeburary ? 5 : 4).fill([]);
+  let flag = 1;
+
+  // TODO: 리팩토링
+  const result = DateArr.map(week => {
+    for (let i = 0; i < WEEKDAY.length; i += 1) {
+      if (firstDate > 0 || fullDate <= 0) {
+        firstDate -= 1;
+        week = [...week, 0];
+      } else {
+        week = [...week, flag];
+        flag += 1;
+        fullDate -= 1;
+      }
+    }
+    return week;
+  });
+  return result;
+};
+
+export function Schedule(): JSX.Element {
+  const testYear = 2022;
+  const tesyMonth = 4;
+
+  const testFullDate = getMonthDate(testYear, tesyMonth);
+
+  return (
+    <S.ScheduleWrapper>
+      <S.Calendar>
+        <S.WeekDay>
+          {WEEKDAY.map(value => (
+            <li key={v4()}>{value}</li>
+          ))}
+        </S.WeekDay>
+
+        <S.WeekDate>{testFullDate[]}</S.WeekDate>
+      </S.Calendar>
+      <S.Calendar>d</S.Calendar>
+    </S.ScheduleWrapper>
+  );
+}

--- a/airbnb/src/Component/Schedule/Schedule.tsx
+++ b/airbnb/src/Component/Schedule/Schedule.tsx
@@ -8,7 +8,9 @@ const getMonthDate = (year: number, month: number) => {
   const firstDate: number = -new Date(year, month, 1).getDay(); // 1일이 몇요일인지
   const addDate = fullDate + firstDate;
 
-  const firstWeek = new Array(WEEKDAY.length).map((_, idx) => firstDate + idx);
+  const firstWeek = new Array(WEEKDAY.length)
+    .fill(0)
+    .map((_, idx) => firstDate + idx);
 
   const currentMonth = Array.from(
     { length: Math.floor(addDate / WEEKDAY.length) },
@@ -33,10 +35,16 @@ export function Schedule(): JSX.Element {
             <li key={v4()}>{value}</li>
           ))}
         </S.WeekDay>
-        <S.WeekDate>
-          {/* week.map 돌때 {} 감싸고 ul 태그 더해주기 */}
-          {testFullDate.map(week => week.map(day => <li key={v4()}>{day}</li>))}
-        </S.WeekDate>
+
+        {/* week.map 돌때 {} 감싸고 ul 태그 더해주기 */}
+        {testFullDate.map(week => (
+          <S.WeekDate key={v4()}>
+            {week.map(day => (
+              <li key={v4()}>{day}</li>
+            ))}
+          </S.WeekDate>
+        ))}
+
         <S.WeekDate>{}</S.WeekDate>
       </S.Calendar>
       <S.Calendar>d</S.Calendar>

--- a/airbnb/src/Component/Schedule/ScheduleStyle.tsx
+++ b/airbnb/src/Component/Schedule/ScheduleStyle.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+export const ScheduleWrapper = styled.div`
+  display: flex;
+  height: 512px;
+  width: 916px;
+  border-radius: 40px;
+  padding: 64px 88px;
+  background-color: white;
+  margin-top: 16px;
+`;
+
+export const Calendar = styled.div`
+  display: flex;
+  width: 336px;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const WeekDay = styled.ul`
+  display: flex;
+
+  li {
+    color: #828282;
+    height: 24px;
+    width: 48px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 17px;
+    text-align: center;
+  }
+`;
+
+export const WeekDate = styled.ul`
+  display: flex;
+
+  li {
+    color: #bdbdbd;
+    height: 48px;
+    width: 48px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 17px;
+    text-align: center;
+  }
+`;

--- a/airbnb/src/Component/SearchBar/SearchBarStyle.tsx
+++ b/airbnb/src/Component/SearchBar/SearchBarStyle.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-interface Test {
+interface SearchBarItem {
   width: number;
 }
 
@@ -15,7 +15,7 @@ export const searchBarWrapper = styled.div`
   padding: 16px;
 `;
 
-export const searchBarItem = styled.div<Test>`
+export const searchBarItem = styled.div<SearchBarItem>`
   margin: 0 24px;
   width: ${({ width }) => width}px;
 `;

--- a/airbnb/src/Component/SearchBar/SearchBarStyle.tsx
+++ b/airbnb/src/Component/SearchBar/SearchBarStyle.tsx
@@ -15,6 +15,7 @@ export const searchBarWrapper = styled.div`
   padding: 16px;
 `;
 
+// 스타일드 컴포넌트 호출시 제네릭 타입으로 SearchBarItems를 지정해 받는 인자타입 선언
 export const searchBarItem = styled.div<SearchBarItem>`
   margin: 0 24px;
   width: ${({ width }) => width}px;

--- a/airbnb/src/Context/Searching/index.tsx
+++ b/airbnb/src/Context/Searching/index.tsx
@@ -1,8 +1,8 @@
 import React, { useReducer, Dispatch } from 'react';
 
 const calendarInitialState: CalenderState = {
-  startDate: new Date(),
-  endDate: new Date(),
+  startDate: 0,
+  endDate: 0,
 };
 
 const priceInitialState: PriceState = {
@@ -18,11 +18,8 @@ const customersInitialState: CustomerState = {
 };
 
 // TODO: <SearchingContextState | null> 은 해결했는데 구조분해 할당을 못해서 다시 바꿈 해결방법 요망
-export const SearchingContext = React.createContext<SearchingContextState>({
-  price: priceInitialState,
-  customers: customersInitialState,
-  calendar: calendarInitialState,
-});
+export const SearchingContext =
+  React.createContext<SearchingContextState | null>(null);
 
 export const setSerachingContext =
   React.createContext<SearchContextDispatch | null>(null);
@@ -116,8 +113,8 @@ interface SearchContextDispatch {
 }
 // TODO: 작명 직접적인 State 쓰지말것 State는 상태에만 작명 사용하자
 export interface CalenderState {
-  startDate: null | Date;
-  endDate: null | Date;
+  startDate: null | number;
+  endDate: null | number;
 }
 
 export interface PriceState {
@@ -134,8 +131,8 @@ export interface CustomerState {
 
 // TODO: type을 interface로 바꾸려면?
 type CalenderAction =
-  | { type: 'SET_START_DATE'; date: Date }
-  | { type: 'SET_END_DATE'; date: Date }
+  | { type: 'SET_START_DATE'; date: number }
+  | { type: 'SET_END_DATE'; date: number }
   | { type: 'RESET' };
 
 type PriceAction =

--- a/airbnb/src/Context/Searching/index.tsx
+++ b/airbnb/src/Context/Searching/index.tsx
@@ -1,15 +1,92 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, Dispatch } from 'react';
 
-const SearchingContext = React.createContext(null);
-const setSerachingContext = React.createContext(null);
+const calendarInitialState: CalenderState = {
+  startDate: new Date(),
+  endDate: new Date(),
+};
 
-export function SearchingProvider({ children }: { childeren: JSX.Element }) {
+const priceInitialState: PriceState = {
+  minimumPrice: 0,
+  maximuPrice: 0,
+  guesthouseNumber: 0,
+};
+
+const customersInitialState: CustomerState = {
+  adultCount: 0,
+  kidsCount: 0,
+  smallChildCount: 0,
+};
+
+// TODO: <SearchingContextState | null> 은 해결했는데 구조분해 할당을 못해서 다시 바꿈 해결방법 요망
+export const SearchingContext = React.createContext<SearchingContextState>({
+  price: priceInitialState,
+  customers: customersInitialState,
+  calendar: calendarInitialState,
+});
+
+export const setSerachingContext =
+  React.createContext<SearchContextDispatch | null>(null);
+
+const calenderReducer = (
+  state: CalenderState,
+  action: CalenderAction,
+): CalenderState => {
+  switch (action.type) {
+    case 'SET_START_DATE':
+      return { ...state, startDate: action.date };
+
+    case 'SET_END_DATE':
+      return { ...state, endDate: action.date };
+
+    case 'RESET':
+      return { ...calendarInitialState };
+
+    default:
+      // TODO: action.type 에러 never type에 action.type 형식 할당 불가능 에러 해결하기
+      throw new Error(`잘못된 달력 액션입니다. actionType: ${action}`);
+  }
+};
+
+const priceReducer = (state: PriceState, action: PriceAction): PriceState => {
+  switch (action.type) {
+    case 'SET_MINIMUM_PRICE':
+      return { ...state, minimumPrice: action.income };
+
+    case 'SET_MAXIMUM_PRICE':
+      return { ...state, maximuPrice: action.income };
+
+    case 'RESET':
+      return { ...priceInitialState };
+
+    default:
+      throw new Error(`잘못된 달력 액션입니다. actionType: ${action}`);
+  }
+};
+
+const customersReducer = (
+  state: CustomerState,
+  action: CustomerAction,
+): CustomerState => {
+  switch (action.type) {
+    case 'SET_ADULT_COUNT':
+      return { ...state, adultCount: action.income };
+    default:
+      throw new Error(`잘못된 액션입니다. actionType: ${action}`);
+  }
+};
+export function SearchingProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
   // TODO: 커스텀훅을 통한 상태 리팩토링
   const [calendar, calendarDispatch] = useReducer(
-    calendarReducer,
+    calenderReducer,
     calendarInitialState,
   );
+
   const [price, priceDispatch] = useReducer(priceReducer, priceInitialState);
+
   const [customers, customersDispatch] = useReducer(
     customersReducer,
     customersInitialState,
@@ -25,3 +102,49 @@ export function SearchingProvider({ children }: { childeren: JSX.Element }) {
     </SearchingContext.Provider>
   );
 }
+
+export interface SearchingContextState {
+  calendar: CalenderState;
+  price: PriceState;
+  customers: CustomerState;
+}
+
+interface SearchContextDispatch {
+  calendarDispatch: Dispatch<CalenderAction>;
+  priceDispatch: Dispatch<PriceAction>;
+  customersDispatch: Dispatch<CustomerAction>;
+}
+// TODO: 작명 직접적인 State 쓰지말것 State는 상태에만 작명 사용하자
+export interface CalenderState {
+  startDate: null | Date;
+  endDate: null | Date;
+}
+
+export interface PriceState {
+  minimumPrice: number;
+  maximuPrice: number;
+  guesthouseNumber: number;
+}
+
+export interface CustomerState {
+  adultCount: number;
+  kidsCount: number;
+  smallChildCount: number;
+}
+
+// TODO: type을 interface로 바꾸려면?
+type CalenderAction =
+  | { type: 'SET_START_DATE'; date: Date }
+  | { type: 'SET_END_DATE'; date: Date }
+  | { type: 'RESET' };
+
+type PriceAction =
+  | { type: 'SET_MINIMUM_PRICE'; income: number }
+  | { type: 'SET_MAXIMUM_PRICE'; income: number }
+  | { type: 'RESET' };
+
+type CustomerAction =
+  | { type: 'SET_ADULT_COUNT'; income: number }
+  | { type: 'SET_KIDS_COUNT'; income: number }
+  | { type: 'SET_SMALL_KIDS_COUNT'; income: number }
+  | { type: 'RESET' };

--- a/airbnb/src/Pages/Home.tsx
+++ b/airbnb/src/Pages/Home.tsx
@@ -1,8 +1,15 @@
+import { useContext } from 'react';
 import Box from '@mui/material/Box';
+import { SearchingContext } from '../Context/Searching';
 import { GNB } from '../Component/GNB';
 import { SearchBar } from '../Component/SearchBar';
+import { Schedule } from '../Component/Schedule/Schedule';
 
 export function Home() {
+  // 문제점 null 일경우에 null. price, null.customers 는 불가능해서 에러
+  // 구조분해 할당을 어떻게 해야할까?
+  const { price, customers, calendar } = useContext(SearchingContext);
+
   return (
     <Box
       display="flex"
@@ -16,11 +23,12 @@ export function Home() {
         margin: '0 auto',
         backgroundImage: `url(https://s3-alpha-sig.figma.com/img/7197/3c13/5882a37ecf9a1d0a40a9d0ab7837c66f?Expires=1654473600&Signature=alJLZ3edAkCL1hqf4s6FWWu8l0WMjMzMuWGnubiQwp7j4VSITgLS4dSLbkvUrH~ClJFKCnyhgKv-RN86UhPHM~5xcfZOthf7k5ICmhZKI6Hvzaj3oiYx8r4rJ6869hhY9SSDMGteZ63MxRqzYrS3AIAOxYsN7faHXdY6P6~1xF-2WzhM1yuV2i-RRp495w4A8LSezSt-4wLaB9aDpjGy38t~M8lhoantdiPa3-4Jf0NIfifU8BU5tFHHN3j9xelYT9Jabc8BRxW52lSYGYtUgg3IjVGw2wQF6EdAWadA5SpYGLex7iUmfqIWsE9wp1s3vYw2JUPYFE8OqNMGYhQcsg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA)`,
         backgroundSize: 'cover',
-        backgroundPosition: 'center',
+        backgroundPosition: 'bottom',
       }}
     >
       <GNB />
       <SearchBar />
+      <Schedule />
     </Box>
   );
 }

--- a/airbnb/src/Pages/Home.tsx
+++ b/airbnb/src/Pages/Home.tsx
@@ -1,6 +1,4 @@
-import { useContext } from 'react';
 import Box from '@mui/material/Box';
-import { SearchingContext } from '../Context/Searching';
 import { GNB } from '../Component/GNB';
 import { SearchBar } from '../Component/SearchBar';
 import { Schedule } from '../Component/Schedule/Schedule';
@@ -8,7 +6,6 @@ import { Schedule } from '../Component/Schedule/Schedule';
 export function Home() {
   // 문제점 null 일경우에 null. price, null.customers 는 불가능해서 에러
   // 구조분해 할당을 어떻게 해야할까?
-  const { price, customers, calendar } = useContext(SearchingContext);
 
   return (
     <Box


### PR DESCRIPTION
안녕하세요 남세 리뷰어님! 날이 많이 더워졌네요. 금요일은 정신이 없어서 피알이 많이 늦어지네요 ㅜㅜ 
이동을 해야할것 같아서 진행사항 등은 추후 PR 메세지에 업데이트 하겠습니다!

## 질문

### 1.
Action 타입을 지정 해주어야 할 사항에서 고민중인 부분입니다.
interface vs type 중 interface가 extends를 통한 타입 확장이 가능하단 글을 봐서 되도록이면
interface를 사용하려 하는데 Action 타입을 선언하면서 문제를 겪고 있습니다.
{type:'RESET'} 일 경우에 income이 필요가 없는데 interface 일 경우에 ?: 를통해서 구현을해도 되고 안해도 되는 식으로 정의했는데
액션 타입이 RESET 이 아닐 경우에도 income을 잡아주지 않아서 문제라고 생각하고 있었습니다. 
이런상황에서는 어쩔수 없이 type으로 정의해야하는지? 아니면 감수하고 인터페이스 타입을 ?: 으로 선언 해야할지 궁금합니다.  

```javaScript
// case1
type CustomerAction =
  | { type: 'SET_ADUULT_COUNT'; income: number }
  | { type: 'SET_KIDS_COUNT'; income: number }
  | { type: 'SET_SMALL_KIDS_COUNT'; income: number }
  | { type: 'RESET' };

----

// case2

interface CustomerAction {
  type:
    | 'SET_ADUULT_COUNT'
    | 'SET_KIDS_COUNT'
    | 'SET_SMALL_KIDS_COUNT'
    | 'RESET';
  income?: number;
}

```

### 2.
컨텍스트를 생성하면서 생긴 문제 입니다. 

```javaScript
export const SearchingContext =
  React.createContext<SearchingContextState | null>(null);
```
컨텍스트를 null로 초기 생성 하기위해  타입을 null 또는 SearchingContextState(인터페이스) 로 선언했습니다.
그런데 이럴경우에 하위 컴포넌트에서 컨텍스트를 받을때 SearchingContextState | null 타입이기 때문에 
null 타입으로 인해 구조분해 할당을 하지 못 하고 있었습니다.

```javaScript

// 생각한 해결책

export const SearchingContext = React.createContext<SearchingContextState>({
  price: priceInitialState,
  customers: customersInitialState,
  calendar: calendarInitialState,
});
```

생각한 해결책으로 컨텍스트를 생성할때 null 값을 안주고 이니셜 데이터 타입과 값을 주는것으로 해결해 보았는데
useReducer로 초기상태 값을 정의해야하는데 굳이 이렇게 한번더 초기값을 설정하는게 의미가 있는가? 중복이 아닌가? 
라는 생각이 들었습니다. 
컨텍스트를 생성할때 타입 지정 관련하여 이런 상황을 어떻게 해결해야할지 키워드를 감을 잡지 못해서 여쭤 볼 수 있을까요?
