### PR TITLE
[Team-08][iOS] Calendar View / UIBezierPath Column Graph 작업

### DIFF
--- a/iOS/.gitignore
+++ b/iOS/.gitignore
@@ -105,3 +105,6 @@ xcuserdata
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift,swiftpackagemanager
+
+### AppCode ###
+.idea

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F3D283B877700EA32E0 /* WishModel.swift */; };
 		00A85F41283B87A300EA32E0 /* MyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F40283B87A300EA32E0 /* MyInfoViewController.swift */; };
 		00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F43283B87B900EA32E0 /* MyInfoModel.swift */; };
+		00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F134592845F20A0087A83C /* CalendarViewCell.swift */; };
 		1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */; };
 		1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */; };
 		1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */; };
@@ -98,6 +99,7 @@
 		00A85F3D283B877700EA32E0 /* WishModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishModel.swift; sourceTree = "<group>"; };
 		00A85F40283B87A300EA32E0 /* MyInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoViewController.swift; sourceTree = "<group>"; };
 		00A85F43283B87B900EA32E0 /* MyInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoModel.swift; sourceTree = "<group>"; };
+		00F134592845F20A0087A83C /* CalendarViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewCell.swift; sourceTree = "<group>"; };
 		1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTitleCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTwoInARowCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOneInARowCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				0029729B2844B4DF0033437E /* CalendarViewController.swift */,
+				00F134592845F20A0087A83C /* CalendarViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 				1BF0618828459A210043FF2F /* Reservations.swift in Sources */,
 				008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */,
 				1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */,
+				00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,
 				1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E236283CA5A900FCB990 /* SearchCellCommonType.swift */; };
 		1B69F369283CD506001A2860 /* MultipleRowsCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B69F368283CD506001A2860 /* MultipleRowsCollectionViewController.swift */; };
 		1B69F36B283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B69F36A283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift */; };
+		1B7EB7F32844E5A70078D4A9 /* NetworkServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7F22844E5A70078D4A9 /* NetworkServices.swift */; };
+		1B7EB7F52844E5B10078D4A9 /* NetworkCommonComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7F42844E5B10078D4A9 /* NetworkCommonComponents.swift */; };
+		1B7EB7FD2844F1290078D4A9 /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7FC2844F1290078D4A9 /* SearchUseCase.swift */; };
+		1B7EB7FF2844FB800078D4A9 /* AirbnbSearchUseCaseResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7FE2844FB800078D4A9 /* AirbnbSearchUseCaseResponseTests.swift */; };
 		1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */; };
 		1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */; };
 		1B90ED36283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */; };
@@ -93,6 +97,10 @@
 		1B27E236283CA5A900FCB990 /* SearchCellCommonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCellCommonType.swift; sourceTree = "<group>"; };
 		1B69F368283CD506001A2860 /* MultipleRowsCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleRowsCollectionViewController.swift; sourceTree = "<group>"; };
 		1B69F36A283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleRowsCollectionViewContainerCell.swift; sourceTree = "<group>"; };
+		1B7EB7F22844E5A70078D4A9 /* NetworkServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServices.swift; sourceTree = "<group>"; };
+		1B7EB7F42844E5B10078D4A9 /* NetworkCommonComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommonComponents.swift; sourceTree = "<group>"; };
+		1B7EB7FC2844F1290078D4A9 /* SearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
+		1B7EB7FE2844FB800078D4A9 /* AirbnbSearchUseCaseResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbSearchUseCaseResponseTests.swift; sourceTree = "<group>"; };
 		1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCalendarModel.swift; sourceTree = "<group>"; };
 		1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDayDTO.swift; sourceTree = "<group>"; };
 		1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbCalendarModelTests.swift; sourceTree = "<group>"; };
@@ -156,6 +164,7 @@
 		005AF78D283B775300546D5B /* Airbnb */ = {
 			isa = PBXGroup;
 			children = (
+				1B7EB7F12844E5990078D4A9 /* Network */,
 				00A85F32283B870700EA32E0 /* MyInfo */,
 				00A85F31283B86FC00EA32E0 /* WishList */,
 				005AF7C2283B843700546D5B /* Search */,
@@ -170,6 +179,7 @@
 			children = (
 				005AF7A5283B775300546D5B /* AirbnbTests.swift */,
 				1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */,
+				1B7EB7FE2844FB800078D4A9 /* AirbnbSearchUseCaseResponseTests.swift */,
 			);
 			path = AirbnbTests;
 			sourceTree = "<group>";
@@ -286,6 +296,16 @@
 				008A20A5283FE3960095F7BC /* HeaderReusableView.swift */,
 			);
 			path = SubView;
+			sourceTree = "<group>";
+		};
+		1B7EB7F12844E5990078D4A9 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				1B7EB7F22844E5A70078D4A9 /* NetworkServices.swift */,
+				1B7EB7F42844E5B10078D4A9 /* NetworkCommonComponents.swift */,
+				1B7EB7FC2844F1290078D4A9 /* SearchUseCase.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		1B807DCD283F540500D6815F /* DTO */ = {
@@ -443,18 +463,21 @@
 				00A85F41283B87A300EA32E0 /* MyInfoViewController.swift in Sources */,
 				008A2064283F62910095F7BC /* LocationCollectionViewCell.swift in Sources */,
 				008A2062283F4E220095F7BC /* BackgroundViewController.swift in Sources */,
+				1B7EB7F52844E5B10078D4A9 /* NetworkCommonComponents.swift in Sources */,
 				00230CF1283BB77500802765 /* TabBarViewController.swift in Sources */,
 				1B69F369283CD506001A2860 /* MultipleRowsCollectionViewController.swift in Sources */,
 				00330A9D283BF91A009014AF /* LocationViewController.swift in Sources */,
 				1B27E235283CA44400FCB990 /* SearchViewModel.swift in Sources */,
 				1B69F36B283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift in Sources */,
 				1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */,
+				1B7EB7FD2844F1290078D4A9 /* SearchUseCase.swift in Sources */,
 				005AF78F283B775300546D5B /* AppDelegate.swift in Sources */,
 				008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */,
 				1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,
 				1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */,
+				1B7EB7F32844E5A70078D4A9 /* NetworkServices.swift in Sources */,
 				00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -465,6 +488,7 @@
 			files = (
 				005AF7A6283B775300546D5B /* AirbnbTests.swift in Sources */,
 				1B90ED36283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift in Sources */,
+				1B7EB7FF2844FB800078D4A9 /* AirbnbSearchUseCaseResponseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */; };
 		1B90ED36283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */; };
 		1BF0618828459A210043FF2F /* Reservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618728459A210043FF2F /* Reservations.swift */; };
+		1BF0618C2845CF8D0043FF2F /* PriceGraphViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */; };
+		1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,6 +112,8 @@
 		1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDayDTO.swift; sourceTree = "<group>"; };
 		1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbCalendarModelTests.swift; sourceTree = "<group>"; };
 		1BF0618728459A210043FF2F /* Reservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reservations.swift; sourceTree = "<group>"; };
+		1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceGraphViewController.swift; sourceTree = "<group>"; };
+		1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnGraphView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -219,6 +223,7 @@
 		005AF7C2283B843700546D5B /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				1BF061892845CF310043FF2F /* Graph */,
 				002972972844B45C0033437E /* Calendar */,
 				00A85F36283B872E00EA32E0 /* View */,
 				00A85F33283B871900EA32E0 /* Model */,
@@ -339,6 +344,23 @@
 				1BF0618728459A210043FF2F /* Reservations.swift */,
 			);
 			path = DTO;
+			sourceTree = "<group>";
+		};
+		1BF061892845CF310043FF2F /* Graph */ = {
+			isa = PBXGroup;
+			children = (
+				1BF0618A2845CF3E0043FF2F /* View */,
+			);
+			path = Graph;
+			sourceTree = "<group>";
+		};
+		1BF0618A2845CF3E0043FF2F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */,
+				1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -504,7 +526,9 @@
 				1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,
+				1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */,
 				1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */,
+				1BF0618C2845CF8D0043FF2F /* PriceGraphViewController.swift in Sources */,
 				1B7EB7F32844E5A70078D4A9 /* NetworkServices.swift in Sources */,
 				00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */,
 			);

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F134592845F20A0087A83C /* CalendarViewCell.swift */; };
 		1B18F7EF28488456005B1CAF /* CustomRangeSliderThumbLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */; };
 		1B18F7F128489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18F7F028489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift */; };
+		1B18F7F52848A71D005B1CAF /* SearchHeadCountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18F7F42848A71D005B1CAF /* SearchHeadCountViewController.swift */; };
 		1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */; };
 		1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */; };
 		1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */; };
@@ -108,6 +109,7 @@
 		00F134592845F20A0087A83C /* CalendarViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewCell.swift; sourceTree = "<group>"; };
 		1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeSliderThumbLayer.swift; sourceTree = "<group>"; };
 		1B18F7F028489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeSliderTrackLayer.swift; sourceTree = "<group>"; };
+		1B18F7F42848A71D005B1CAF /* SearchHeadCountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHeadCountViewController.swift; sourceTree = "<group>"; };
 		1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTitleCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTwoInARowCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOneInARowCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				1B27E22D283CA11200FCB990 /* SubView */,
 				00A85F37283B873F00EA32E0 /* SearchViewController.swift */,
 				00330A9C283BF91A009014AF /* LocationViewController.swift */,
+				1B18F7F42848A71D005B1CAF /* SearchHeadCountViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -556,6 +559,7 @@
 				1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */,
 				1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */,
 				1BF061902845F31E0043FF2F /* CommonColors.swift in Sources */,
+				1B18F7F52848A71D005B1CAF /* SearchHeadCountViewController.swift in Sources */,
 				1BF0618C2845CF8D0043FF2F /* PriceGraphViewController.swift in Sources */,
 				1B7EB7F32844E5A70078D4A9 /* NetworkServices.swift in Sources */,
 				00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		00A85F41283B87A300EA32E0 /* MyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F40283B87A300EA32E0 /* MyInfoViewController.swift */; };
 		00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F43283B87B900EA32E0 /* MyInfoModel.swift */; };
 		00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F134592845F20A0087A83C /* CalendarViewCell.swift */; };
+		1B18F7EF28488456005B1CAF /* CustomRangeSliderThumbLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */; };
 		1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */; };
 		1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */; };
 		1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */; };
@@ -104,6 +105,7 @@
 		00A85F40283B87A300EA32E0 /* MyInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoViewController.swift; sourceTree = "<group>"; };
 		00A85F43283B87B900EA32E0 /* MyInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoModel.swift; sourceTree = "<group>"; };
 		00F134592845F20A0087A83C /* CalendarViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewCell.swift; sourceTree = "<group>"; };
+		1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeSliderThumbLayer.swift; sourceTree = "<group>"; };
 		1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTitleCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTwoInARowCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOneInARowCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 				1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */,
 				1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */,
 				1B756E71284855CE003AC0EA /* CustomRangeSlider.swift */,
+				1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -520,6 +523,7 @@
 				00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */,
 				1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */,
 				1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */,
+				1B18F7EF28488456005B1CAF /* CustomRangeSliderThumbLayer.swift in Sources */,
 				0029729628445B8D0033437E /* LocationModel.swift in Sources */,
 				1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */,
 				00A85F35283B872800EA32E0 /* ReservationModel.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F43283B87B900EA32E0 /* MyInfoModel.swift */; };
 		00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F134592845F20A0087A83C /* CalendarViewCell.swift */; };
 		1B18F7EF28488456005B1CAF /* CustomRangeSliderThumbLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */; };
+		1B18F7F128489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B18F7F028489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift */; };
 		1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */; };
 		1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */; };
 		1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */; };
@@ -106,6 +107,7 @@
 		00A85F43283B87B900EA32E0 /* MyInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoModel.swift; sourceTree = "<group>"; };
 		00F134592845F20A0087A83C /* CalendarViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewCell.swift; sourceTree = "<group>"; };
 		1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeSliderThumbLayer.swift; sourceTree = "<group>"; };
+		1B18F7F028489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeSliderTrackLayer.swift; sourceTree = "<group>"; };
 		1B27E22E283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTitleCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E230283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTwoInARowCollectionViewCell.swift; sourceTree = "<group>"; };
 		1B27E232283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOneInARowCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 				1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */,
 				1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */,
 				1B756E71284855CE003AC0EA /* CustomRangeSlider.swift */,
+				1B18F7F028489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift */,
 				1B18F7EE28488456005B1CAF /* CustomRangeSliderThumbLayer.swift */,
 			);
 			path = View;
@@ -535,6 +538,7 @@
 				00230CF1283BB77500802765 /* TabBarViewController.swift in Sources */,
 				1B69F369283CD506001A2860 /* MultipleRowsCollectionViewController.swift in Sources */,
 				00330A9D283BF91A009014AF /* LocationViewController.swift in Sources */,
+				1B18F7F128489EA5005B1CAF /* CustomRangeSliderTrackLayer.swift in Sources */,
 				1B27E235283CA44400FCB990 /* SearchViewModel.swift in Sources */,
 				1B69F36B283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift in Sources */,
 				1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B27E236283CA5A900FCB990 /* SearchCellCommonType.swift */; };
 		1B69F369283CD506001A2860 /* MultipleRowsCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B69F368283CD506001A2860 /* MultipleRowsCollectionViewController.swift */; };
 		1B69F36B283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B69F36A283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift */; };
+		1B756E702848533B003AC0EA /* CommonTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B756E6F2848533B003AC0EA /* CommonTableViewController.swift */; };
+		1B756E72284855CE003AC0EA /* CustomRangeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B756E71284855CE003AC0EA /* CustomRangeSlider.swift */; };
 		1B7EB7F32844E5A70078D4A9 /* NetworkServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7F22844E5A70078D4A9 /* NetworkServices.swift */; };
 		1B7EB7F52844E5B10078D4A9 /* NetworkCommonComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7F42844E5B10078D4A9 /* NetworkCommonComponents.swift */; };
 		1B7EB7FD2844F1290078D4A9 /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7EB7FC2844F1290078D4A9 /* SearchUseCase.swift */; };
@@ -109,6 +111,8 @@
 		1B27E236283CA5A900FCB990 /* SearchCellCommonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCellCommonType.swift; sourceTree = "<group>"; };
 		1B69F368283CD506001A2860 /* MultipleRowsCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleRowsCollectionViewController.swift; sourceTree = "<group>"; };
 		1B69F36A283D0D9C001A2860 /* MultipleRowsCollectionViewContainerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleRowsCollectionViewContainerCell.swift; sourceTree = "<group>"; };
+		1B756E6F2848533B003AC0EA /* CommonTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTableViewController.swift; sourceTree = "<group>"; };
+		1B756E71284855CE003AC0EA /* CustomRangeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeSlider.swift; sourceTree = "<group>"; };
 		1B7EB7F22844E5A70078D4A9 /* NetworkServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServices.swift; sourceTree = "<group>"; };
 		1B7EB7F42844E5B10078D4A9 /* NetworkCommonComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCommonComponents.swift; sourceTree = "<group>"; };
 		1B7EB7FC2844F1290078D4A9 /* SearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
@@ -238,6 +242,7 @@
 				00A85F33283B871900EA32E0 /* Model */,
 				1B807DCD283F540500D6815F /* DTO */,
 				008A2061283F4E220095F7BC /* BackgroundViewController.swift */,
+				1B756E6F2848533B003AC0EA /* CommonTableViewController.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -368,6 +373,7 @@
 			children = (
 				1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */,
 				1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */,
+				1B756E71284855CE003AC0EA /* CustomRangeSlider.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -531,8 +537,10 @@
 				1B7EB7FD2844F1290078D4A9 /* SearchUseCase.swift in Sources */,
 				005AF78F283B775300546D5B /* AppDelegate.swift in Sources */,
 				1BF0618828459A210043FF2F /* Reservations.swift in Sources */,
+				1B756E702848533B003AC0EA /* CommonTableViewController.swift in Sources */,
 				008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */,
 				1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */,
+				1B756E72284855CE003AC0EA /* CustomRangeSlider.swift in Sources */,
 				00863C4D284609DD004E5954 /* CalendarHearderView.swift in Sources */,
 				00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */; };
 		1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */; };
 		1B90ED36283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */; };
+		1BF0618828459A210043FF2F /* Reservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618728459A210043FF2F /* Reservations.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +105,7 @@
 		1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCalendarModel.swift; sourceTree = "<group>"; };
 		1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDayDTO.swift; sourceTree = "<group>"; };
 		1B90ED35283F5B4A00E45FE8 /* AirbnbCalendarModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbCalendarModelTests.swift; sourceTree = "<group>"; };
+		1BF0618728459A210043FF2F /* Reservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reservations.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -312,6 +314,7 @@
 			isa = PBXGroup;
 			children = (
 				1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */,
+				1BF0618728459A210043FF2F /* Reservations.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -472,6 +475,7 @@
 				1B27E22F283CA12D00FCB990 /* SearchTitleCollectionViewCell.swift in Sources */,
 				1B7EB7FD2844F1290078D4A9 /* SearchUseCase.swift in Sources */,
 				005AF78F283B775300546D5B /* AppDelegate.swift in Sources */,
+				1BF0618828459A210043FF2F /* Reservations.swift in Sources */,
 				008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */,
 				1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00230CF1283BB77500802765 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00230CF0283BB77500802765 /* TabBarViewController.swift */; };
+		0029729628445B8D0033437E /* LocationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0029729528445B8D0033437E /* LocationModel.swift */; };
 		00330A9D283BF91A009014AF /* LocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00330A9C283BF91A009014AF /* LocationViewController.swift */; };
 		003514E4283CC8C00078514F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 003514E3283CC8C00078514F /* SnapKit */; };
 		003514E7283CC8DA0078514F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 003514E6283CC8DA0078514F /* Alamofire */; };
@@ -73,6 +74,7 @@
 
 /* Begin PBXFileReference section */
 		00230CF0283BB77500802765 /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
+		0029729528445B8D0033437E /* LocationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationModel.swift; sourceTree = "<group>"; };
 		00330A9C283BF91A009014AF /* LocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationViewController.swift; sourceTree = "<group>"; };
 		005AF78B283B775300546D5B /* Airbnb.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Airbnb.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		005AF78E283B775300546D5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				00A85F34283B872800EA32E0 /* SearchModel.swift */,
+				0029729528445B8D0033437E /* LocationModel.swift */,
 				1B27E234283CA44400FCB990 /* SearchViewModel.swift */,
 				1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */,
 			);
@@ -460,6 +463,7 @@
 				00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */,
 				1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */,
 				1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */,
+				0029729628445B8D0033437E /* LocationModel.swift in Sources */,
 				1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */,
 				00A85F35283B872800EA32E0 /* SearchModel.swift in Sources */,
 				00A85F3C283B876A00EA32E0 /* WishListViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		005AF798283B775300546D5B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 005AF797283B775300546D5B /* Assets.xcassets */; };
 		005AF7A6283B775300546D5B /* AirbnbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005AF7A5283B775300546D5B /* AirbnbTests.swift */; };
 		00863C4D284609DD004E5954 /* CalendarHearderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C4C284609DD004E5954 /* CalendarHearderView.swift */; };
+		00863C4F2847452F004E5954 /* CalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C4E2847452F004E5954 /* CalendarModel.swift */; };
+		00863C5128474614004E5954 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C5028474614004E5954 /* Day.swift */; };
+		00863C5328474792004E5954 /* MonthMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C5228474792004E5954 /* MonthMetadata.swift */; };
 		008A2062283F4E220095F7BC /* BackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2061283F4E220095F7BC /* BackgroundViewController.swift */; };
 		008A2064283F62910095F7BC /* LocationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */; };
 		008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A20A5283FE3960095F7BC /* HeaderReusableView.swift */; };
@@ -92,6 +95,9 @@
 		005AF7A5283B775300546D5B /* AirbnbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbTests.swift; sourceTree = "<group>"; };
 		005AF7AB283B775300546D5B /* AirbnbUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirbnbUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00863C4C284609DD004E5954 /* CalendarHearderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHearderView.swift; sourceTree = "<group>"; };
+		00863C4E2847452F004E5954 /* CalendarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarModel.swift; sourceTree = "<group>"; };
+		00863C5028474614004E5954 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
+		00863C5228474792004E5954 /* MonthMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthMetadata.swift; sourceTree = "<group>"; };
 		008A2061283F4E220095F7BC /* BackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewController.swift; sourceTree = "<group>"; };
 		008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCollectionViewCell.swift; sourceTree = "<group>"; };
 		008A20A5283FE3960095F7BC /* HeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderReusableView.swift; sourceTree = "<group>"; };
@@ -268,6 +274,8 @@
 				0029729528445B8D0033437E /* LocationModel.swift */,
 				1B27E234283CA44400FCB990 /* SearchViewModel.swift */,
 				1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */,
+				00863C4E2847452F004E5954 /* CalendarModel.swift */,
+				00863C5228474792004E5954 /* MonthMetadata.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -350,6 +358,7 @@
 			isa = PBXGroup;
 			children = (
 				1B90ED33283F547600E45FE8 /* SearchDayDTO.swift */,
+				00863C5028474614004E5954 /* Day.swift */,
 				1BF0618728459A210043FF2F /* Reservations.swift */,
 			);
 			path = DTO;
@@ -511,10 +520,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				0029729C2844B4DF0033437E /* CalendarViewController.swift in Sources */,
+				00863C5328474792004E5954 /* MonthMetadata.swift in Sources */,
 				00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */,
 				1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */,
 				1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */,
 				0029729628445B8D0033437E /* LocationModel.swift in Sources */,
+				00863C4F2847452F004E5954 /* CalendarModel.swift in Sources */,
 				1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */,
 				00A85F35283B872800EA32E0 /* ReservationModel.swift in Sources */,
 				00A85F3C283B876A00EA32E0 /* WishListViewController.swift in Sources */,
@@ -537,6 +548,7 @@
 				00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,
+				00863C5128474614004E5954 /* Day.swift in Sources */,
 				1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */,
 				1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */,
 				1BF061902845F31E0043FF2F /* CommonColors.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		005AF791283B775300546D5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005AF790283B775300546D5B /* SceneDelegate.swift */; };
 		005AF798283B775300546D5B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 005AF797283B775300546D5B /* Assets.xcassets */; };
 		005AF7A6283B775300546D5B /* AirbnbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005AF7A5283B775300546D5B /* AirbnbTests.swift */; };
+		00863C4D284609DD004E5954 /* CalendarHearderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00863C4C284609DD004E5954 /* CalendarHearderView.swift */; };
 		008A2062283F4E220095F7BC /* BackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2061283F4E220095F7BC /* BackgroundViewController.swift */; };
 		008A2064283F62910095F7BC /* LocationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */; };
 		008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A20A5283FE3960095F7BC /* HeaderReusableView.swift */; };
@@ -90,6 +91,7 @@
 		005AF7A1283B775300546D5B /* AirbnbTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirbnbTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		005AF7A5283B775300546D5B /* AirbnbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirbnbTests.swift; sourceTree = "<group>"; };
 		005AF7AB283B775300546D5B /* AirbnbUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirbnbUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		00863C4C284609DD004E5954 /* CalendarHearderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHearderView.swift; sourceTree = "<group>"; };
 		008A2061283F4E220095F7BC /* BackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewController.swift; sourceTree = "<group>"; };
 		008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCollectionViewCell.swift; sourceTree = "<group>"; };
 		008A20A5283FE3960095F7BC /* HeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderReusableView.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 			children = (
 				0029729B2844B4DF0033437E /* CalendarViewController.swift */,
 				00F134592845F20A0087A83C /* CalendarViewCell.swift */,
+				00863C4C284609DD004E5954 /* CalendarHearderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -530,6 +533,7 @@
 				1BF0618828459A210043FF2F /* Reservations.swift in Sources */,
 				008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */,
 				1B27E237283CA5A900FCB990 /* SearchCellCommonType.swift in Sources */,
+				00863C4D284609DD004E5954 /* CalendarHearderView.swift in Sources */,
 				00F1345A2845F20A0087A83C /* CalendarViewCell.swift in Sources */,
 				00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */,
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		00230CF1283BB77500802765 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00230CF0283BB77500802765 /* TabBarViewController.swift */; };
 		0029729628445B8D0033437E /* LocationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0029729528445B8D0033437E /* LocationModel.swift */; };
+		0029729C2844B4DF0033437E /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0029729B2844B4DF0033437E /* CalendarViewController.swift */; };
 		00330A9D283BF91A009014AF /* LocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00330A9C283BF91A009014AF /* LocationViewController.swift */; };
 		003514E4283CC8C00078514F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 003514E3283CC8C00078514F /* SnapKit */; };
 		003514E7283CC8DA0078514F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 003514E6283CC8DA0078514F /* Alamofire */; };
@@ -19,7 +20,7 @@
 		008A2062283F4E220095F7BC /* BackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2061283F4E220095F7BC /* BackgroundViewController.swift */; };
 		008A2064283F62910095F7BC /* LocationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */; };
 		008A20A6283FE3960095F7BC /* HeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008A20A5283FE3960095F7BC /* HeaderReusableView.swift */; };
-		00A85F35283B872800EA32E0 /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F34283B872800EA32E0 /* SearchModel.swift */; };
+		00A85F35283B872800EA32E0 /* ReservationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F34283B872800EA32E0 /* ReservationModel.swift */; };
 		00A85F38283B873F00EA32E0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F37283B873F00EA32E0 /* SearchViewController.swift */; };
 		00A85F3C283B876A00EA32E0 /* WishListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F3B283B876A00EA32E0 /* WishListViewController.swift */; };
 		00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A85F3D283B877700EA32E0 /* WishModel.swift */; };
@@ -75,6 +76,7 @@
 /* Begin PBXFileReference section */
 		00230CF0283BB77500802765 /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		0029729528445B8D0033437E /* LocationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationModel.swift; sourceTree = "<group>"; };
+		0029729B2844B4DF0033437E /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		00330A9C283BF91A009014AF /* LocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationViewController.swift; sourceTree = "<group>"; };
 		005AF78B283B775300546D5B /* Airbnb.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Airbnb.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		005AF78E283B775300546D5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -87,7 +89,7 @@
 		008A2061283F4E220095F7BC /* BackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundViewController.swift; sourceTree = "<group>"; };
 		008A2063283F62910095F7BC /* LocationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCollectionViewCell.swift; sourceTree = "<group>"; };
 		008A20A5283FE3960095F7BC /* HeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderReusableView.swift; sourceTree = "<group>"; };
-		00A85F34283B872800EA32E0 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
+		00A85F34283B872800EA32E0 /* ReservationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationModel.swift; sourceTree = "<group>"; };
 		00A85F37283B873F00EA32E0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		00A85F3B283B876A00EA32E0 /* WishListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListViewController.swift; sourceTree = "<group>"; };
 		00A85F3D283B877700EA32E0 /* WishModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishModel.swift; sourceTree = "<group>"; };
@@ -143,6 +145,22 @@
 				00230CF0283BB77500802765 /* TabBarViewController.swift */,
 			);
 			path = TabBar;
+			sourceTree = "<group>";
+		};
+		002972972844B45C0033437E /* Calendar */ = {
+			isa = PBXGroup;
+			children = (
+				002972982844B4770033437E /* View */,
+			);
+			path = Calendar;
+			sourceTree = "<group>";
+		};
+		002972982844B4770033437E /* View */ = {
+			isa = PBXGroup;
+			children = (
+				0029729B2844B4DF0033437E /* CalendarViewController.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		005AF782283B775200546D5B = {
@@ -201,6 +219,7 @@
 		005AF7C2283B843700546D5B /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				002972972844B45C0033437E /* Calendar */,
 				00A85F36283B872E00EA32E0 /* View */,
 				00A85F33283B871900EA32E0 /* Model */,
 				1B807DCD283F540500D6815F /* DTO */,
@@ -231,7 +250,7 @@
 		00A85F33283B871900EA32E0 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				00A85F34283B872800EA32E0 /* SearchModel.swift */,
+				00A85F34283B872800EA32E0 /* ReservationModel.swift */,
 				0029729528445B8D0033437E /* LocationModel.swift */,
 				1B27E234283CA44400FCB990 /* SearchViewModel.swift */,
 				1B807DCA283F529A00D6815F /* SearchCalendarModel.swift */,
@@ -460,12 +479,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0029729C2844B4DF0033437E /* CalendarViewController.swift in Sources */,
 				00A85F3E283B877700EA32E0 /* WishModel.swift in Sources */,
 				1B807DCB283F529A00D6815F /* SearchCalendarModel.swift in Sources */,
 				1B27E233283CA14900FCB990 /* SearchOneInARowCollectionViewCell.swift in Sources */,
 				0029729628445B8D0033437E /* LocationModel.swift in Sources */,
 				1B27E231283CA14200FCB990 /* SearchTwoInARowCollectionViewCell.swift in Sources */,
-				00A85F35283B872800EA32E0 /* SearchModel.swift in Sources */,
+				00A85F35283B872800EA32E0 /* ReservationModel.swift in Sources */,
 				00A85F3C283B876A00EA32E0 /* WishListViewController.swift in Sources */,
 				00A85F41283B87A300EA32E0 /* MyInfoViewController.swift in Sources */,
 				008A2064283F62910095F7BC /* LocationCollectionViewCell.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		1BF0618828459A210043FF2F /* Reservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618728459A210043FF2F /* Reservations.swift */; };
 		1BF0618C2845CF8D0043FF2F /* PriceGraphViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */; };
 		1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */; };
+		1BF061902845F31E0043FF2F /* CommonColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF0618F2845F31E0043FF2F /* CommonColors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -114,6 +115,7 @@
 		1BF0618728459A210043FF2F /* Reservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reservations.swift; sourceTree = "<group>"; };
 		1BF0618B2845CF8D0043FF2F /* PriceGraphViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceGraphViewController.swift; sourceTree = "<group>"; };
 		1BF0618D2845CFBE0043FF2F /* ColumnGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnGraphView.swift; sourceTree = "<group>"; };
+		1BF0618F2845F31E0043FF2F /* CommonColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonColors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -216,6 +218,7 @@
 				005AF78E283B775300546D5B /* AppDelegate.swift */,
 				005AF790283B775300546D5B /* SceneDelegate.swift */,
 				005AF797283B775300546D5B /* Assets.xcassets */,
+				1BF0618F2845F31E0043FF2F /* CommonColors.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				005AF791283B775300546D5B /* SceneDelegate.swift in Sources */,
 				1BF0618E2845CFBE0043FF2F /* ColumnGraphView.swift in Sources */,
 				1B90ED34283F547600E45FE8 /* SearchDayDTO.swift in Sources */,
+				1BF061902845F31E0043FF2F /* CommonColors.swift in Sources */,
 				1BF0618C2845CF8D0043FF2F /* PriceGraphViewController.swift in Sources */,
 				1B7EB7F32844E5A70078D4A9 /* NetworkServices.swift in Sources */,
 				00A85F44283B87B900EA32E0 /* MyInfoModel.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Info.plist
+++ b/iOS/Airbnb/Airbnb/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/iOS/Airbnb/Airbnb/Network/NetworkCommonComponents.swift
+++ b/iOS/Airbnb/Airbnb/Network/NetworkCommonComponents.swift
@@ -1,0 +1,18 @@
+//
+//  NetworkCommonComponents.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/30.
+//
+
+import Foundation
+import Alamofire
+
+class NetworkCommonComponents {
+    private(set) var baseURL: URL?
+    let services = NetworkServices()
+    
+    init(urlString: String) {
+        self.baseURL = URL(string: urlString)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Network/NetworkServices.swift
+++ b/iOS/Airbnb/Airbnb/Network/NetworkServices.swift
@@ -26,7 +26,7 @@ class NetworkServices {
     /// 예약관련
     /// GET : 파라미터 없음. 예약리스트 출력함
     /// POST : roomId, checkInDate, checkOutDate, headcount, totalCharge. 예약하기
-    let reservations = "/reservations"
+    let reservations = "\(api)/reservations"
     
     /// 숙소 예약 요금 계산(1)
     /// POST : checkInDate, checkOutDate, headcount

--- a/iOS/Airbnb/Airbnb/Network/NetworkServices.swift
+++ b/iOS/Airbnb/Airbnb/Network/NetworkServices.swift
@@ -1,0 +1,68 @@
+//
+//  NetworkServices.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/30.
+//
+
+import Foundation
+
+class NetworkServices {
+    
+    static let api = "/api"
+    
+    /// 근처의 인기 여행지 기본 화면
+    let destination = "\(NetworkServices.api)/destination"
+    /// 근처의 인기 여행지 검색
+    /// GET : destination="검색어"
+    /// POST : location, checkInDate, checkOutDate, minCharge, maxCharge, headcount
+    let rooms: String = "\(NetworkServices.api)/rooms"
+    /// 숙소 상세
+    /// GET : id
+    lazy var roomsWithID: (String) -> String = {
+        return "\(self.rooms)/\($0)"
+    }
+    
+    /// 예약관련
+    /// GET : 파라미터 없음. 예약리스트 출력함
+    /// POST : roomId, checkInDate, checkOutDate, headcount, totalCharge. 예약하기
+    let reservations = "/reservations"
+    
+    /// 숙소 예약 요금 계산(1)
+    /// POST : checkInDate, checkOutDate, headcount
+    /// URL에 첨부하기 위해 숙소 id 추가
+    lazy var totalChange: (String) -> String = {
+        return "\(self.reservations)/\($0)/totalCharge"
+    }
+    /// 숙소 예약 요금 계산(2)
+    /// POST : checkInDate, checkOutDate, headcount
+    /// URL에 첨부하기 위해 숙소 id 추가
+    lazy var calculateChange: (String) -> String = {
+        return "\(self.reservations)/calculateCharge/\($0)"
+    }
+    
+    /// 예약 상세
+    /// GET : 파라미터 없음
+    /// URL에 첨부하기 위해 예약 id 추가
+    lazy var reservationsDetail: (String) -> String = {
+        return "\(self.reservations)/\($0)"
+    }
+    
+    /// 위시리스트 목록
+    /// GET : 파라미터 없음
+    static let wish = "\(NetworkServices.api)/wish"
+    
+    /// 위시리스트 삭제
+    /// DELETE : 파라미터 없음
+    /// URL에 첨부하기 위해 위시id 추가
+    lazy var wishDelete: (String) -> String = {
+        return "\(NetworkServices.wish)/\($0)"
+    }
+    
+    /// 위시리스트 등록
+    /// POST : wishId, boolParam(boolParam 은 정보 없음)
+    /// URL에 첨부하기 위해 위시id 추가
+    lazy var wishInsert: (String) -> String = {
+        return "\(NetworkServices.wish)/\($0)"
+    }
+}

--- a/iOS/Airbnb/Airbnb/Network/SearchUseCase.swift
+++ b/iOS/Airbnb/Airbnb/Network/SearchUseCase.swift
@@ -1,0 +1,166 @@
+//
+//  SearchUseCase.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/30.
+//
+
+import Foundation
+import Alamofire
+
+class SearchUseCase: NetworkCommonComponents {
+    
+    func getPopularCities(_ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.destination) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .get
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    func getNearbyCities(name: String, _ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.rooms) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .get,
+            parameters: Destination(destination: name),
+            encoder: JSONParameterEncoder.default
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    func getRoomDetail(roomId: String, _ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.roomsWithID(roomId)) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .get
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    //TODO: - parameter를 DTO로 변경할 예정.
+    func postNearbyCities(location: String, checkInDate: String, checkOutDate: String, minCharge: String, maxCharge: String, headcount: String, _ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.rooms) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .post,
+            parameters: PostNearbyParam(location: location, checkInDate: checkInDate, checkOutDate: checkOutDate, minCharge: minCharge, maxCharge: maxCharge, headcount: headcount),
+            encoder: JSONParameterEncoder.default
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    func getReservations(_ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.reservations) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .get
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    func getTotalChange(roomId: String, checkInDate: String, checkOutDate: String, headcount: String, _ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.totalChange(roomId)) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .post,
+            parameters: TotalChangeParam(checkInDate: checkInDate, checkOutDate: checkOutDate, headcount: headcount),
+            encoder: JSONParameterEncoder.default
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    func postCalculateChange(roomId: String, checkInDate: String, checkOutDate: String, headcount: String, _ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.calculateChange(roomId)) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .post,
+            parameters: TotalChangeParam(checkInDate: checkInDate, checkOutDate: checkOutDate, headcount: headcount),
+            encoder: JSONParameterEncoder.default
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    // TODO: - 예약 상세임. 다른 유스 케이스로 옮겨야 할 수도 있음
+    func getReservationDetail(reservationID: String, completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        guard let url = baseURL?.appendingPathComponent(services.reservationsDetail(reservationID)) else {
+            completionHandler(.failure(SearchNetworkError.URLError))
+            return
+        }
+        
+        AF.request(
+            url,
+            method: .get
+        ).commonRequestComplete(completionHandler)
+    }
+    
+    struct Destination: Codable {
+        let destination: String
+    }
+    
+    struct PostNearbyParam: Codable {
+        var location, checkInDate, checkOutDate, minCharge, maxCharge, headcount: String
+    }
+    
+    struct TotalChangeParam: Codable {
+        var checkInDate, checkOutDate, headcount: String
+    }
+}
+
+extension SearchUseCase {
+    private func commonRequestComplete(_ request: DataRequest, completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        request
+            .validate()
+            .response { response in
+                switch response.result {
+                case .success(let data):
+                    completionHandler(.success(data))
+                case .failure(let error):
+                    completionHandler(.failure(error))
+                }
+            }
+    }
+}
+
+extension SearchUseCase {
+    enum SearchNetworkError: Error {
+        case URLError
+    }
+}
+
+private extension DataRequest {
+    func commonRequestComplete(_ completionHandler: @escaping (Result<Data?, Error>) -> Void) {
+        self
+            .validate()
+            .response { response in
+                switch response.result {
+                case .success(let data):
+                    completionHandler(.success(data))
+                case .failure(let error):
+                    completionHandler(.failure(error))
+                }
+            }
+    }
+}

--- a/iOS/Airbnb/Airbnb/Network/SearchUseCase.swift
+++ b/iOS/Airbnb/Airbnb/Network/SearchUseCase.swift
@@ -69,9 +69,16 @@ class SearchUseCase: NetworkCommonComponents {
             return
         }
         
+        let header = HTTPHeader.init(name: "content-type", value: "application/json")
+//    connection: keep-alive
+//     content-type: application/json
+//     date: Tue,31 May 2022 00:42:49 GMT
+//     keep-alive: timeout=60
+//     transfer-encoding: chunked
         AF.request(
             url,
-            method: .get
+            method: .get,
+            headers: [header]
         ).commonRequestComplete(completionHandler)
     }
     

--- a/iOS/Airbnb/Airbnb/Network/SearchUseCase.swift
+++ b/iOS/Airbnb/Airbnb/Network/SearchUseCase.swift
@@ -70,11 +70,7 @@ class SearchUseCase: NetworkCommonComponents {
         }
         
         let header = HTTPHeader.init(name: "content-type", value: "application/json")
-//    connection: keep-alive
-//     content-type: application/json
-//     date: Tue,31 May 2022 00:42:49 GMT
-//     keep-alive: timeout=60
-//     transfer-encoding: chunked
+        
         AF.request(
             url,
             method: .get,
@@ -123,6 +119,7 @@ class SearchUseCase: NetworkCommonComponents {
         ).commonRequestComplete(completionHandler)
     }
     
+    // Test 를 위한 임시 구조체
     struct Destination: Codable {
         let destination: String
     }

--- a/iOS/Airbnb/Airbnb/Search/BackgroundViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/BackgroundViewController.swift
@@ -17,12 +17,28 @@ class BackgroundViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setUpNavigationAppearance()
+        setUpToolBarAppearance()
     }
     
-    func setUpNavigationAppearance() {
+    private func setUpNavigationAppearance() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .systemGray6
         navigationItem.standardAppearance = appearance
         navigationItem.scrollEdgeAppearance = appearance
+    }
+    
+    private func setUpToolBarAppearance() {
+        navigationController?.toolbar.tintColor = .black
+        let toolBarAppearance = UIToolbarAppearance()
+        toolBarAppearance.configureWithOpaqueBackground()
+        toolBarAppearance.backgroundColor = .systemGray6
+        navigationController?.toolbar.isTranslucent = true
+        navigationController?.toolbar.standardAppearance = toolBarAppearance
+        navigationController?.toolbar.compactAppearance = toolBarAppearance
+        if #available(iOS 15.0, *) {
+            navigationController?.toolbar.scrollEdgeAppearance = toolBarAppearance
+        }
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/BackgroundViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/BackgroundViewController.swift
@@ -22,6 +22,7 @@ class BackgroundViewController: UIViewController {
     }
     
     private func setUpNavigationAppearance() {
+        navigationItem.backButtonTitle = "뒤로"
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = .systemGray6
@@ -30,7 +31,7 @@ class BackgroundViewController: UIViewController {
     }
     
     private func setUpToolBarAppearance() {
-        navigationController?.toolbar.tintColor = .black
+        navigationController?.toolbar.tintColor = .label
         let toolBarAppearance = UIToolbarAppearance()
         toolBarAppearance.configureWithOpaqueBackground()
         toolBarAppearance.backgroundColor = .systemGray6

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarHearderView.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarHearderView.swift
@@ -1,0 +1,18 @@
+//
+//  CalendarHearderView.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/05/31.
+//
+
+import UIKit
+
+class CalendarHearderView: UICollectionReusableView {
+//    override var reuseIdentifier: String?
+}
+
+extension UICollectionReusableView {
+//    static var reuseIdentifier: String { String(describing: Self.self) }
+}
+
+

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarHearderView.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarHearderView.swift
@@ -6,13 +6,60 @@
 //
 
 import UIKit
+import SnapKit
 
 class CalendarHearderView: UICollectionReusableView {
-//    override var reuseIdentifier: String?
+    
+    var baseDate: Date? {
+        didSet {
+            guard let date = baseDate else { return }
+            yearMonthLabel.text = dateFormatter.string(from: date)
+        }
+    }
+    
+    private lazy var dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 M월"
+        return dateFormatter
+    }()
+    
+    private let yearMonthLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 17, weight: .bold)
+        label.accessibilityTraits = .header
+        label.isAccessibilityElement = true
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        addSubview(yearMonthLabel)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        yearMonthLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        yearMonthLabel.text = nil
+    }
 }
 
 extension UICollectionReusableView {
-//    static var reuseIdentifier: String { String(describing: Self.self) }
+    static var reuseIdentifier: String { String(describing: Self.self) }
 }
-
 

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
@@ -10,114 +10,123 @@ import UIKit
 class CalendarViewCell: UICollectionViewCell {
     
     var day: Day? {
-      didSet {
-        guard let day = day else { return }
-
-        numberLabel.text = day.number
-        accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
-        updateSelectionStatus()
-      }
+        didSet {
+            guard let day = day else { return }
+            if day.isWithInDisplayedMonth {
+                numberLabel.text = day.number
+                accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
+                updateSelectionStatus()
+            } else {
+                selectionBackgroundView.isHidden = true
+            }
+        }
     }
-
+    
     
     private lazy var selectionBackgroundView: UIView = {
-      let view = UIView()
-      view.translatesAutoresizingMaskIntoConstraints = false
-      view.clipsToBounds = true
-      view.backgroundColor = .systemRed
-      return view
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = true
+        view.backgroundColor = .gray1
+        return view
     }()
-
+    
     private lazy var numberLabel: UILabel = {
-      let label = UILabel()
-      label.translatesAutoresizingMaskIntoConstraints = false
-      label.textAlignment = .center
-      label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
-      label.textColor = .label
-      return label
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
+        label.textColor = .label
+        return label
     }()
-
+    
     private lazy var accessibilityDateFormatter: DateFormatter = {
-      let dateFormatter = DateFormatter()
-      dateFormatter.calendar = Calendar(identifier: .gregorian)
-      dateFormatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d")
-      return dateFormatter
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        dateFormatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d")
+        return dateFormatter
     }()
-
+    
     override init(frame: CGRect) {
-      super.init(frame: frame)
-
-      isAccessibilityElement = true
-      accessibilityTraits = .button
-      contentView.addSubview(selectionBackgroundView)
-      contentView.addSubview(numberLabel)
+        super.init(frame: frame)
+        
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        contentView.addSubview(selectionBackgroundView)
+        contentView.addSubview(numberLabel)
     }
-
+    
     required init?(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func layoutSubviews() {
-      super.layoutSubviews()
-
-      NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
-
-      let size = traitCollection.horizontalSizeClass == .compact ?
+        super.layoutSubviews()
+        
+        NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
+        
+        let size = traitCollection.horizontalSizeClass == .compact ?
         min(min(frame.width, frame.height) - 10, 60) : 45
-
-      NSLayoutConstraint.activate([
-        numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-        numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-
-        selectionBackgroundView.centerYAnchor
-          .constraint(equalTo: numberLabel.centerYAnchor),
-        selectionBackgroundView.centerXAnchor
-          .constraint(equalTo: numberLabel.centerXAnchor),
-        selectionBackgroundView.widthAnchor.constraint(equalToConstant: size),
-        selectionBackgroundView.heightAnchor
-          .constraint(equalTo: selectionBackgroundView.widthAnchor)
-      ])
-
-      selectionBackgroundView.layer.cornerRadius = size / 2
-
+        
+        NSLayoutConstraint.activate([
+            numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            
+            selectionBackgroundView.centerYAnchor
+                .constraint(equalTo: numberLabel.centerYAnchor),
+            selectionBackgroundView.centerXAnchor
+                .constraint(equalTo: numberLabel.centerXAnchor),
+            selectionBackgroundView.widthAnchor.constraint(equalToConstant: size),
+            selectionBackgroundView.heightAnchor
+                .constraint(equalTo: selectionBackgroundView.widthAnchor)
+        ])
+        
+        selectionBackgroundView.layer.cornerRadius = size / 2
+        
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        numberLabel.text = nil
     }
 }
 
 // MARK: - Appearance
 private extension CalendarViewCell {
-  
-  func updateSelectionStatus() {
-    guard let day = day else { return }
-
-    if day.isSelected {
-      applySelectedStyle()
-    } else {
-        applyDefaultStyle()
+    
+    func updateSelectionStatus() {
+        guard let day = day else { return }
+        
+        if day.isSelected {
+            applySelectedStyle()
+        } else {
+            applyDefaultStyle()
+        }
     }
-  }
-
-  var isSmallScreenSize: Bool {
-    let isCompact = traitCollection.horizontalSizeClass == .compact
-    let smallWidth = UIScreen.main.bounds.width <= 350
-    let widthGreaterThanHeight =
-      UIScreen.main.bounds.width > UIScreen.main.bounds.height
-
-    return isCompact && (smallWidth || widthGreaterThanHeight)
-  }
-
-  func applySelectedStyle() {
-    accessibilityTraits.insert(.selected)
-    accessibilityHint = nil
-
-    numberLabel.textColor = isSmallScreenSize ? .systemRed : .white
-    selectionBackgroundView.isHidden = isSmallScreenSize
-  }
-
-  func applyDefaultStyle() {
-    accessibilityTraits.remove(.selected)
-    accessibilityHint = "Tap to select"
-
-    numberLabel.textColor = .label
-    selectionBackgroundView.isHidden = true
-  }
+    
+    var isSmallScreenSize: Bool {
+        let isCompact = traitCollection.horizontalSizeClass == .compact
+        let smallWidth = UIScreen.main.bounds.width <= 350
+        let widthGreaterThanHeight =
+        UIScreen.main.bounds.width > UIScreen.main.bounds.height
+        
+        return isCompact && (smallWidth || widthGreaterThanHeight)
+    }
+    
+    func applySelectedStyle() {
+        accessibilityTraits.insert(.selected)
+        accessibilityHint = nil
+        
+        numberLabel.textColor = isSmallScreenSize ? .systemRed : .white
+        selectionBackgroundView.isHidden = isSmallScreenSize
+    }
+    
+    func applyDefaultStyle() {
+        accessibilityTraits.remove(.selected)
+        accessibilityHint = "Tap to select"
+        
+        numberLabel.textColor = .label
+        selectionBackgroundView.isHidden = true
+    }
+    
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
@@ -9,11 +9,11 @@ import UIKit
 
 class CalendarViewCell: UICollectionViewCell {
     
-    var day: SearchDayDTO? {
+    var day: Day? {
       didSet {
         guard let day = day else { return }
 
-        numberLabel.text = day.day
+        numberLabel.text = day.number
         accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
         updateSelectionStatus()
       }
@@ -59,18 +59,12 @@ class CalendarViewCell: UICollectionViewCell {
     
     override func layoutSubviews() {
       super.layoutSubviews()
-      
-      // This allows for rotations and trait collection
-      // changes (e.g. entering split view on iPad) to update constraints correctly.
-      // Removing old constraints allows for new ones to be created
-      // regardless of the values of the old ones
+
       NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
 
-      // 1
       let size = traitCollection.horizontalSizeClass == .compact ?
         min(min(frame.width, frame.height) - 10, 60) : 45
 
-      // 2
       NSLayoutConstraint.activate([
         numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
         numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -91,18 +85,17 @@ class CalendarViewCell: UICollectionViewCell {
 
 // MARK: - Appearance
 private extension CalendarViewCell {
-  // 1
+  
   func updateSelectionStatus() {
     guard let day = day else { return }
 
     if day.isSelected {
       applySelectedStyle()
     } else {
-        applyDefaultStyle(isWithinDisplayedMonth: day.isOccupied)
+        applyDefaultStyle()
     }
   }
 
-  // 2
   var isSmallScreenSize: Bool {
     let isCompact = traitCollection.horizontalSizeClass == .compact
     let smallWidth = UIScreen.main.bounds.width <= 350
@@ -112,7 +105,6 @@ private extension CalendarViewCell {
     return isCompact && (smallWidth || widthGreaterThanHeight)
   }
 
-  // 3
   func applySelectedStyle() {
     accessibilityTraits.insert(.selected)
     accessibilityHint = nil
@@ -121,12 +113,11 @@ private extension CalendarViewCell {
     selectionBackgroundView.isHidden = isSmallScreenSize
   }
 
-  // 4
-  func applyDefaultStyle(isWithinDisplayedMonth: Bool) {
+  func applyDefaultStyle() {
     accessibilityTraits.remove(.selected)
     accessibilityHint = "Tap to select"
 
-    numberLabel.textColor = isWithinDisplayedMonth ? .label : .secondaryLabel
+    numberLabel.textColor = .label
     selectionBackgroundView.isHidden = true
   }
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
@@ -27,7 +27,7 @@ class CalendarViewCell: UICollectionViewCell {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.clipsToBounds = true
-        view.backgroundColor = .gray1
+        view.backgroundColor = UIColor.getGrayScale(.Grey1)
         return view
     }()
     

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewCell.swift
@@ -1,0 +1,132 @@
+//
+//  CalendarViewCell.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/05/31.
+//
+
+import UIKit
+
+class CalendarViewCell: UICollectionViewCell {
+    
+    var day: SearchDayDTO? {
+      didSet {
+        guard let day = day else { return }
+
+        numberLabel.text = day.day
+        accessibilityLabel = accessibilityDateFormatter.string(from: day.date)
+        updateSelectionStatus()
+      }
+    }
+
+    
+    private lazy var selectionBackgroundView: UIView = {
+      let view = UIView()
+      view.translatesAutoresizingMaskIntoConstraints = false
+      view.clipsToBounds = true
+      view.backgroundColor = .systemRed
+      return view
+    }()
+
+    private lazy var numberLabel: UILabel = {
+      let label = UILabel()
+      label.translatesAutoresizingMaskIntoConstraints = false
+      label.textAlignment = .center
+      label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
+      label.textColor = .label
+      return label
+    }()
+
+    private lazy var accessibilityDateFormatter: DateFormatter = {
+      let dateFormatter = DateFormatter()
+      dateFormatter.calendar = Calendar(identifier: .gregorian)
+      dateFormatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d")
+      return dateFormatter
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+
+      isAccessibilityElement = true
+      accessibilityTraits = .button
+      contentView.addSubview(selectionBackgroundView)
+      contentView.addSubview(numberLabel)
+    }
+
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      
+      // This allows for rotations and trait collection
+      // changes (e.g. entering split view on iPad) to update constraints correctly.
+      // Removing old constraints allows for new ones to be created
+      // regardless of the values of the old ones
+      NSLayoutConstraint.deactivate(selectionBackgroundView.constraints)
+
+      // 1
+      let size = traitCollection.horizontalSizeClass == .compact ?
+        min(min(frame.width, frame.height) - 10, 60) : 45
+
+      // 2
+      NSLayoutConstraint.activate([
+        numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+
+        selectionBackgroundView.centerYAnchor
+          .constraint(equalTo: numberLabel.centerYAnchor),
+        selectionBackgroundView.centerXAnchor
+          .constraint(equalTo: numberLabel.centerXAnchor),
+        selectionBackgroundView.widthAnchor.constraint(equalToConstant: size),
+        selectionBackgroundView.heightAnchor
+          .constraint(equalTo: selectionBackgroundView.widthAnchor)
+      ])
+
+      selectionBackgroundView.layer.cornerRadius = size / 2
+
+    }
+}
+
+// MARK: - Appearance
+private extension CalendarViewCell {
+  // 1
+  func updateSelectionStatus() {
+    guard let day = day else { return }
+
+    if day.isSelected {
+      applySelectedStyle()
+    } else {
+        applyDefaultStyle(isWithinDisplayedMonth: day.isOccupied)
+    }
+  }
+
+  // 2
+  var isSmallScreenSize: Bool {
+    let isCompact = traitCollection.horizontalSizeClass == .compact
+    let smallWidth = UIScreen.main.bounds.width <= 350
+    let widthGreaterThanHeight =
+      UIScreen.main.bounds.width > UIScreen.main.bounds.height
+
+    return isCompact && (smallWidth || widthGreaterThanHeight)
+  }
+
+  // 3
+  func applySelectedStyle() {
+    accessibilityTraits.insert(.selected)
+    accessibilityHint = nil
+
+    numberLabel.textColor = isSmallScreenSize ? .systemRed : .white
+    selectionBackgroundView.isHidden = isSmallScreenSize
+  }
+
+  // 4
+  func applyDefaultStyle(isWithinDisplayedMonth: Bool) {
+    accessibilityTraits.remove(.selected)
+    accessibilityHint = "Tap to select"
+
+    numberLabel.textColor = isWithinDisplayedMonth ? .label : .secondaryLabel
+    selectionBackgroundView.isHidden = true
+  }
+}

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -1,0 +1,27 @@
+//
+//  CalendarViewController.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/05/30.
+//
+
+import UIKit
+
+class CalendarViewController: UIViewController {
+    
+    var reservationModel: ReservationModel
+    
+    init(reservationModel: ReservationModel) {
+        self.reservationModel = reservationModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .darkGray
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -7,13 +7,18 @@
 
 import UIKit
 
-class CalendarViewController: UIViewController {
+class CalendarViewController: UIViewController, CommonViewControllerProtocol {
+    
+    
     
     var reservationModel: ReservationModel
     
     init(reservationModel: ReservationModel) {
         self.reservationModel = reservationModel
         super.init(nibName: nil, bundle: nil)
+        attribute()
+        layout()
+        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -23,5 +28,33 @@ class CalendarViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .darkGray
+    }
+    
+    func attribute() {
+        var items = [UIBarButtonItem]()
+        items.append(
+            UIBarButtonItem(title: "건너뛰기", style: .plain, target: self, action: #selector(pushNextVC))
+        )
+        items.append(
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        )
+        items.append(
+            UIBarButtonItem(title: "다음", style: .plain, target: self, action: nil)
+        )
+        self.toolbarItems = items
+    }
+    
+    func layout() {
+        
+    }
+    
+    func bind() {
+        
+    }
+    
+    @objc func pushNextVC() {
+        //TODO: - graphic 관련한 뷰컨트롤러로 변경
+        let nextVC = UIViewController()
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -17,10 +17,9 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         layout.minimumLineSpacing = 0
         layout.minimumInteritemSpacing = 0
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.isScrollEnabled = true
-        collectionView.isPagingEnabled = true
         collectionView.backgroundColor = .systemBackground
         collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.showsVerticalScrollIndicator = false
         return collectionView
     }()
     
@@ -42,6 +41,7 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
     
     private func setUpCollectionViewDelegates() {
         collectionView.register(CalendarViewCell.self, forCellWithReuseIdentifier: CalendarViewCell.reuseIdentifier)
+        collectionView.register(CalendarHearderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: CalendarHearderView.reuseIdentifier)
         collectionView.delegate = self
         collectionView.dataSource = self
     }
@@ -59,7 +59,7 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         
         collectionView.snp.makeConstraints {
             $0.top.leading.trailing.equalTo(view.readableContentGuide)
-            $0.height.equalTo(view.snp.height).multipliedBy(0.6)
+            $0.height.equalTo(view.snp.height).multipliedBy(0.5)
         }
     }
     
@@ -86,25 +86,50 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
 
 extension CalendarViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return calendarModel.days.count
+        return calendarModel.month[section].result.count
     }
     
-//    func numberOfSections(in collectionView: UICollectionView) -> Int {
-//        calendarModel.count
-//    }
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        calendarModel.month.count
+    }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewCell.reuseIdentifier, for: indexPath) as? CalendarViewCell else {
-            return UICollectionViewCell()
-        }
-        let day = calendarModel.days[indexPath.row]
+        guard let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewCell.reuseIdentifier, for: indexPath) as? CalendarViewCell else { return UICollectionViewCell() }
+        let day = calendarModel.month[indexPath.section].result[indexPath.row]
         cell.day = day
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        switch kind {
+        case UICollectionView.elementKindSectionHeader:
+            guard
+                let headerView = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier:  CalendarHearderView.reuseIdentifier,
+                    for: indexPath) as? CalendarHearderView
+            else { return UICollectionReusableView() }
+            
+            let date = calendarModel.month[indexPath.section]
+                .result.last?.date
+            headerView.baseDate = date
+            return headerView
+        default:
+            return UICollectionReusableView()
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        let width: CGFloat = self.collectionView.frame.width
+        let height: CGFloat = 60
+        return CGSize(width: width, height: height)
     }
 }
 
 extension CalendarViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: self.collectionView.frame.width / 7, height: self.collectionView.frame.width / 7)
+        let width: Int = Int(self.collectionView.frame.width / 7)
+        let height: Int = 50
+        return CGSize(width: width, height: height)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -11,6 +11,8 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
     
     let reservationModel: ReservationModel
     let calendarModel = SearchCalendarModel()
+    var resultArray: [CalendarResult] = []
+    var date = Date()
     
     private let calendar = Calendar(identifier: .gregorian)
     
@@ -20,9 +22,10 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         layout.minimumInteritemSpacing = 0
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.isScrollEnabled = false
+        collectionView.isScrollEnabled = true
+        collectionView.isPagingEnabled = true
         //TODO: - 캘린더 완성되면 지울 내용 - 빨간 배경색
-        collectionView.backgroundColor = .red
+        collectionView.backgroundColor = .systemBackground
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
@@ -41,6 +44,16 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         attribute()
         layout()
         bind()
+        // 12달 만들기
+        for _ in 0..<12 {
+            let nextMonthResult = calendarModel.getNextMonthDays(from: date)
+            self.resultArray.append(nextMonthResult)
+            self.date = nextMonthResult.date
+        }
+        collectionView.register(CalendarViewCell.self, forCellWithReuseIdentifier: CalendarViewCell.reuseIdentifier)
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.reloadData()
     }
     
     func attribute() {
@@ -75,5 +88,33 @@ class CalendarViewController: BackgroundViewController, CommonViewControllerProt
         //TODO: - graphic 관련한 뷰컨트롤러로 변경
         let nextVC = PriceGraphViewController()
         self.navigationController?.pushViewController(nextVC, animated: true)
+    }
+}
+
+extension CalendarViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        35
+    }
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        self.resultArray.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewCell.reuseIdentifier, for: indexPath) as? CalendarViewCell else {
+            return UICollectionViewCell()
+        }
+        guard self.resultArray[indexPath.section].result.count - 1 >= indexPath.row else {
+            return cell
+        }
+        let day = self.resultArray[indexPath.section].result[indexPath.row]
+        cell.day = day
+        return cell
+    }
+}
+
+extension CalendarViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: self.collectionView.frame.width / 7, height: self.collectionView.frame.width / 7)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -7,49 +7,68 @@
 
 import UIKit
 
-class CalendarViewController: UIViewController, CommonViewControllerProtocol {
+class CalendarViewController: BackgroundViewController, CommonViewControllerProtocol {
     
+    let reservationModel: ReservationModel
+    let calendarModel = SearchCalendarModel()
     
+    private let calendar = Calendar(identifier: .gregorian)
     
-    var reservationModel: ReservationModel
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumLineSpacing = 0
+        layout.minimumInteritemSpacing = 0
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.isScrollEnabled = false
+        //TODO: - 캘린더 완성되면 지울 내용 - 빨간 배경색
+        collectionView.backgroundColor = .red
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        return collectionView
+    }()
     
     init(reservationModel: ReservationModel) {
         self.reservationModel = reservationModel
         super.init(nibName: nil, bundle: nil)
-        attribute()
-        layout()
-        bind()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .darkGray
+        attribute()
+        layout()
+        bind()
     }
     
     func attribute() {
-        var items = [UIBarButtonItem]()
-        items.append(
-            UIBarButtonItem(title: "건너뛰기", style: .plain, target: self, action: #selector(pushNextVC))
-        )
-        items.append(
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
-        )
-        items.append(
-            UIBarButtonItem(title: "다음", style: .plain, target: self, action: nil)
-        )
-        self.toolbarItems = items
+        view.backgroundColor = .systemBackground
+        navigationItem.title = "숙소 찾기"
+        navigationController?.isToolbarHidden = false
+        self.toolbarItems = setUpToolBarItems()
     }
     
     func layout() {
+        view.addSubview(collectionView)
         
+        collectionView.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(view.readableContentGuide)
+            $0.height.equalTo(view.snp.height).multipliedBy(0.6)
+        }
     }
     
     func bind() {
         
+    }
+    
+    private func setUpToolBarItems() -> [UIBarButtonItem] {
+        let spacing = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        let skipButton = UIBarButtonItem(title: "건너뛰기", style: .plain, target: self, action: #selector(pushNextVC))
+        let nextButton = UIBarButtonItem(title: "다음", style: .plain, target: self, action: nil)
+        nextButton.isEnabled = false
+        return [skipButton, spacing, nextButton]
     }
     
     @objc func pushNextVC() {

--- a/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Calendar/View/CalendarViewController.swift
@@ -54,7 +54,7 @@ class CalendarViewController: UIViewController, CommonViewControllerProtocol {
     
     @objc func pushNextVC() {
         //TODO: - graphic 관련한 뷰컨트롤러로 변경
-        let nextVC = UIViewController()
+        let nextVC = PriceGraphViewController()
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/CommonTableViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/CommonTableViewController.swift
@@ -1,0 +1,12 @@
+//
+//  CommonTableViewController.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/06/02.
+//
+
+import Foundation
+
+class CommonTableViewController: BackgroundViewController {
+    
+}

--- a/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
+++ b/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
@@ -11,6 +11,7 @@ struct Day {
     let date: Date
     let number: String
     let isSelected: Bool
+    let isWithInDisplayedMonth: Bool
     var fadeState: FadeState = .none
 }
 

--- a/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
+++ b/iOS/Airbnb/Airbnb/Search/DTO/Day.swift
@@ -1,0 +1,19 @@
+//
+//  Day.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/06/01.
+//
+
+import Foundation
+
+struct Day {
+    let date: Date
+    let number: String
+    let isSelected: Bool
+    var fadeState: FadeState = .none
+}
+
+enum FadeState {
+    case left, right, fill, none
+}

--- a/iOS/Airbnb/Airbnb/Search/DTO/Reservations.swift
+++ b/iOS/Airbnb/Airbnb/Search/DTO/Reservations.swift
@@ -1,0 +1,39 @@
+//
+//  Reservations.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/31.
+//
+
+import Foundation
+
+struct Reservations: Codable {
+    var reservations: [ReservationItem]
+    
+    struct ReservationItem: Codable {
+        var reservationID: Int
+        var headCount: Int
+        var totalCharge: Int
+        var roomName: String
+        var roomType: String
+        var mainImageUrl: String
+        var checkInDate: String
+        var checkOutDate: String
+        var address: Address
+        var host: Host
+    }
+    
+    struct Address: Codable {
+        var country: String
+        var city: String
+        var state: String
+        var street: String
+        var detailAddress: String
+    }
+
+    struct Host: Codable {
+        var id: Int
+        var name: String
+        var profileImageUrl: String
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/DTO/SearchDayDTO.swift
+++ b/iOS/Airbnb/Airbnb/Search/DTO/SearchDayDTO.swift
@@ -15,8 +15,10 @@ struct SearchDayDTO {
     let isOccupied: Bool
     
     let isSelected: Bool = false
-    // 선택되었을 시 왼쪽부터 서서히 채워나가는 이펙트를 줌
-    var fadeLeft: Bool = false
-    // 선택되었을 시 오른쪽부터 서서히 채워나가는 이펙트를 줌
-    var fadeRight: Bool = false
+
+    var fadeState: FadeState = .none
+    
+    enum FadeState {
+        case left, right, fill, none
+    }
 }

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/ColumnGraphView.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/ColumnGraphView.swift
@@ -54,8 +54,6 @@ class ColumnGraphView: UIView {
             }
         }
         
-        UIColor(named: "Grey3")?.set()
-        
         let maskingLayer = CAShapeLayer()
         maskingLayer.path = path.cgPath
         

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/ColumnGraphView.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/ColumnGraphView.swift
@@ -5,7 +5,6 @@
 //  Created by 백상휘 on 2022/05/31.
 //
 
-import Foundation
 import UIKit
 
 class ColumnGraphView: UIView {
@@ -29,8 +28,7 @@ class ColumnGraphView: UIView {
         
         let graphHeight = rect.maxY
         let paddingSum: CGFloat = distribution.count == 0 ? 0 : CGFloat(distribution.count - 1) * columnInnerPadding
-        let columnWidthSum = rect.width - (columnLeadingPadding + columnTrailingPadding) - paddingSum
-        let columnWidth = columnWidthSum / CGFloat(distribution.count)
+        let columnWidth = (rect.width - paddingSum) / CGFloat(distribution.count)
         
         let path = UIBezierPath()
         path.lineWidth = 2
@@ -39,23 +37,20 @@ class ColumnGraphView: UIView {
         
         path.move(to: CGPoint(x: 0, y: rect.maxY))
         
-        var graphMovedXPosition = columnLeadingPadding
+        var graphMovedXPosition: CGFloat = 0
         
-        UIView.animate(withDuration: 0.8) {
-            for (x, y) in self.distribution.enumerated() {
-                
-                path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * 1))
-                path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * (1-y)))
-                
-                graphMovedXPosition += columnWidth
-                
-                path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * (1-y)))
-                path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * 1))
-                
-                if x != self.distribution.count - 1 {
-                    graphMovedXPosition += self.columnInnerPadding
-                    path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight))
-                }
+        for (x, y) in self.distribution.enumerated() {
+            path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * 1))
+            path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * (1-y)))
+            
+            graphMovedXPosition += columnWidth
+            
+            path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * (1-y)))
+            path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight * 1))
+            
+            if x != self.distribution.count - 1 {
+                graphMovedXPosition += self.columnInnerPadding
+                path.addLine(to: CGPoint(x: graphMovedXPosition, y: graphHeight))
             }
         }
         

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/ColumnGraphView.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/ColumnGraphView.swift
@@ -1,0 +1,53 @@
+//
+//  ColumnGraphView.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/31.
+//
+
+import Foundation
+import UIKit
+
+class ColumnGraphView: UIView {
+    
+    private var yRange: [Int] = []
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .clear
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.backgroundColor = .clear
+    }
+    
+    override func draw(_ rect: CGRect) {
+        
+        let graphHeight = Int(rect.maxY)
+        let path = UIBezierPath()
+        path.lineWidth = 2
+        path.lineJoinStyle = .miter
+        path.usesEvenOddFillRule = true
+        
+        path.move(to: CGPoint(x: 0, y: rect.maxY))
+        
+        for (x, y) in yRange.enumerated() {
+            let xFrom = (x+1) * 10
+            let xTo = ((x+1) * 10) + 10
+            
+            path.addLine(to: CGPoint(x: xFrom+2, y: graphHeight))
+            path.addLine(to: CGPoint(x: xFrom+2, y: graphHeight-y))
+            path.addLine(to: CGPoint(x: xTo, y: graphHeight-y))
+            path.addLine(to: CGPoint(x: xTo, y: graphHeight))
+        }
+        
+        UIColor(named: "Grey3")?.set()
+        path.fill()
+    }
+    
+    func drawGraph(distribution: [Int]) {
+        self.yRange = distribution
+        self.draw(bounds)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
@@ -1,0 +1,71 @@
+//
+//  CustomRangeSlider.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/06/02.
+//
+
+import UIKit
+import QuartzCore
+
+class CustomRangeSlider: UIView {
+    
+    var minimumValue: CGFloat = 0.0
+    var maximumValue: CGFloat = 1.0
+    var lowerValue: CGFloat = 0.2
+    var upperValue: CGFloat = 0.8
+    
+    let (trackLayer, lowerThumbLayer, upperThumbLayer) = (CALayer(), CALayer(), CALayer())
+    
+    var thumbWidth: CGFloat {
+        CGFloat(bounds.height)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        trackLayer.backgroundColor = UIColor.getGrayScale(.Grey3)?.cgColor
+        layer.addSublayer(trackLayer)
+        
+        lowerThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
+        layer.addSublayer(lowerThumbLayer)
+        
+        upperThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
+        layer.addSublayer(upperThumbLayer)
+        
+        updateLayerFrames()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func updateLayerFrames() {
+        trackLayer.frame = bounds.insetBy(dx: 0.0, dy: bounds.height / 3)
+        trackLayer.setNeedsDisplay()
+
+        let lowerThumbCenter = CGFloat(positionForValue(value: lowerValue))
+        
+        lowerThumbLayer.frame = CGRect(
+                x: lowerThumbCenter - thumbWidth / 2.0,
+                y: 0.0,
+                width: thumbWidth,
+                height: thumbWidth
+        )
+        lowerThumbLayer.setNeedsDisplay()
+        
+        let upperThumbCenter = CGFloat(positionForValue(value: upperValue))
+        
+        upperThumbLayer.frame = CGRect(
+                x: upperThumbCenter - thumbWidth / 2.0,
+                y: 0.0,
+                width: thumbWidth,
+                height: thumbWidth
+        )
+        upperThumbLayer.setNeedsDisplay()
+    }
+    
+    func positionForValue(value: Double) -> Double {
+        Double(bounds.width - thumbWidth) * (value - minimumValue) / (maximumValue - minimumValue) + Double(thumbWidth / 2.0)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
@@ -37,6 +37,11 @@ class CustomRangeSlider: UIControl {
         upperThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
         layer.addSublayer(upperThumbLayer)
         
+        if let thumbImage = UIImage(named: "PauseCircle") {
+            lowerThumbLayer.backgroundColor = UIColor(patternImage: thumbImage).cgColor
+            upperThumbLayer.backgroundColor = UIColor(patternImage: thumbImage).cgColor
+        }
+        
         updateLayerFrames()
     }
     
@@ -111,6 +116,8 @@ class CustomRangeSlider: UIControl {
         updateLayerFrames()
         
         CATransaction.commit()
+        
+        sendActions(for: .valueChanged)
         
         return true
     }

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
@@ -15,7 +15,13 @@ class CustomRangeSlider: UIControl {
     var lowerValue: CGFloat = 0.2
     var upperValue: CGFloat = 0.8
     
-    let (trackLayer, lowerThumbLayer, upperThumbLayer) = (CALayer(), CustomRangeSliderThumbLayer(), CustomRangeSliderThumbLayer())
+    let (trackLayer, lowerThumbLayer, upperThumbLayer) = (CustomRangeSliderTrackLayer(), CustomRangeSliderThumbLayer(), CustomRangeSliderThumbLayer())
+    
+    var trackTintColor = UIColor.getGrayScale(.Grey4)
+    var trackHighlightTintColor = UIColor.getGrayScale(.Grey3)
+    var thumbTintColor = UIColor.white
+    
+    var curvanceousness: CGFloat = 1.0
     
     var thumbWidth: CGFloat {
         CGFloat(bounds.height)
@@ -26,21 +32,20 @@ class CustomRangeSlider: UIControl {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        trackLayer.rangeSlider = self
+        trackLayer.contentsScale = UIScreen.main.scale
         trackLayer.backgroundColor = UIColor.getGrayScale(.Grey3)?.cgColor
         layer.addSublayer(trackLayer)
         
         lowerThumbLayer.rangeSlider = self
+        lowerThumbLayer.contentsScale = UIScreen.main.scale
         lowerThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
         layer.addSublayer(lowerThumbLayer)
         
         upperThumbLayer.rangeSlider = self
+        upperThumbLayer.contentsScale = UIScreen.main.scale
         upperThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
         layer.addSublayer(upperThumbLayer)
-        
-        if let thumbImage = UIImage(named: "PauseCircle") {
-            lowerThumbLayer.backgroundColor = UIColor(patternImage: thumbImage).cgColor
-            upperThumbLayer.backgroundColor = UIColor(patternImage: thumbImage).cgColor
-        }
         
         updateLayerFrames()
     }
@@ -61,6 +66,7 @@ class CustomRangeSlider: UIControl {
                 width: thumbWidth,
                 height: thumbWidth
         )
+        lowerThumbLayer.contents = UIImage(named: "PauseCircle")?.cgImage
         lowerThumbLayer.setNeedsDisplay()
         
         let upperThumbCenter = CGFloat(positionForValue(value: upperValue))
@@ -71,6 +77,7 @@ class CustomRangeSlider: UIControl {
                 width: thumbWidth,
                 height: thumbWidth
         )
+        upperThumbLayer.contents = UIImage(named: "PauseCircle")?.cgImage
         upperThumbLayer.setNeedsDisplay()
     }
     

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSlider.swift
@@ -39,12 +39,10 @@ class CustomRangeSlider: UIControl {
         
         lowerThumbLayer.rangeSlider = self
         lowerThumbLayer.contentsScale = UIScreen.main.scale
-        lowerThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
         layer.addSublayer(lowerThumbLayer)
         
         upperThumbLayer.rangeSlider = self
         upperThumbLayer.contentsScale = UIScreen.main.scale
-        upperThumbLayer.backgroundColor = UIColor.getGrayScale(.Grey1)?.cgColor
         layer.addSublayer(upperThumbLayer)
         
         updateLayerFrames()
@@ -67,7 +65,6 @@ class CustomRangeSlider: UIControl {
                 height: thumbWidth
         )
         lowerThumbLayer.contents = UIImage(named: "PauseCircle")?.cgImage
-        lowerThumbLayer.setNeedsDisplay()
         
         let upperThumbCenter = CGFloat(positionForValue(value: upperValue))
         
@@ -78,7 +75,6 @@ class CustomRangeSlider: UIControl {
                 height: thumbWidth
         )
         upperThumbLayer.contents = UIImage(named: "PauseCircle")?.cgImage
-        upperThumbLayer.setNeedsDisplay()
     }
     
     func positionForValue(value: Double) -> Double {

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSliderThumbLayer.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSliderThumbLayer.swift
@@ -9,9 +9,6 @@ import UIKit
 import QuartzCore
 
 class CustomRangeSliderThumbLayer: CALayer {
-    
     var highlighted = false
     weak var rangeSlider: CustomRangeSlider?
-    
-    
 }

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSliderThumbLayer.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSliderThumbLayer.swift
@@ -1,0 +1,17 @@
+//
+//  CustomRangeSliderThumbLayer.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/06/02.
+//
+
+import UIKit
+import QuartzCore
+
+class CustomRangeSliderThumbLayer: CALayer {
+    
+    var highlighted = false
+    weak var rangeSlider: CustomRangeSlider?
+    
+    
+}

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSliderTrackLayer.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/CustomRangeSliderTrackLayer.swift
@@ -1,0 +1,32 @@
+//
+//  CustomRangeSliderTrackLayer.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/06/02.
+//
+
+import UIKit
+import QuartzCore
+
+class CustomRangeSliderTrackLayer: CALayer {
+    weak var rangeSlider: CustomRangeSlider?
+    
+    override func draw(in ctx: CGContext) {
+        guard let slider = rangeSlider else {
+            return
+        }
+        
+        let path = UIBezierPath(rect: bounds)
+        ctx.addPath(path.cgPath)
+        
+        ctx.setFillColor((slider.trackTintColor ?? slider.tintColor).cgColor)
+        ctx.addPath(path.cgPath)
+        ctx.fillPath()
+        
+        ctx.setFillColor((slider.trackHighlightTintColor ?? slider.tintColor).cgColor)
+        let lowerValuePosition = CGFloat(slider.positionForValue(value: slider.lowerValue))
+        let upperValuePosition = CGFloat(slider.positionForValue(value: slider.upperValue))
+        let rect = CGRect(x: lowerValuePosition, y: 0.0, width: upperValuePosition - lowerValuePosition, height: bounds.height)
+        ctx.fill(rect)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -14,14 +14,6 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
     
     private let graph = ColumnGraphView()
     private var editableWidth: Constraint?
-//    private let slider: UISlider = {
-//        let slider = UISlider()
-//        slider.minimumValue = 0
-//        slider.maximumValue = 1
-//        slider.thumbTintColor = UIColor.getGrayScale(.Grey3)
-//        slider.tintColor = UIColor.getGrayScale(.Grey3)
-//        return slider
-//    }()
     private var slider = CustomRangeSlider(frame: .zero)
     
     // 그래프의 선택되지 않는 희미한 부분
@@ -85,7 +77,6 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         graph.addSubview(lightGrayView)
         graph.addSubview(semanticGrayView)
         
-        slider.backgroundColor = .red
         view.addSubview(slider)
         
         graph.snp.makeConstraints { make in
@@ -106,17 +97,16 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         }
         
         slider.snp.makeConstraints { make in
-            make.top.equalTo(self.graph.snp.bottom)
+            make.top.equalTo(self.graph.snp.bottom).inset(9)
             make.leading.trailing.equalTo(graph)
-            make.height.equalTo(31)
+            make.height.equalTo(20)
         }
+        slider.layoutIfNeeded()
+        slider.updateLayerFrames()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        print(slider.frame)
-        slider.updateLayerFrames()
-        slider.layoutIfNeeded()
     }
     
     func bind() {

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -19,28 +19,30 @@ class PriceGraphViewController: UIViewController {
         let slider = UISlider()
         slider.minimumValue = 0
         slider.maximumValue = 1
-        slider.thumbTintColor = UIColor(named: "Grey3")
-        slider.setThumbImage(UIImage(named: "PauseCircle"), for: .normal)
+        slider.thumbTintColor = UIColor.gray3
+        slider.tintColor = UIColor.gray3
         return slider
     }()
     
     private lazy var priceLabel: (String) -> UILabel = {
         let label = UILabel()
         label.text = $0
-        label.textColor = UIColor(named: "Grey1")
+        label.textColor = UIColor.gray1
         self.view.addSubview(label)
         return label
     }
     
+    // 그래프의 선택되지 않는 희미한 부분
     private let lightGrayView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(named: "Grey4")
+        view.backgroundColor = UIColor.gray4
         return view
     }()
     
+    // 그래프에서 선택되는 진한 부분
     let semanticGrayView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(named: "Grey3")
+        view.backgroundColor = UIColor.gray3
         return view
     }()
     
@@ -61,12 +63,12 @@ class PriceGraphViewController: UIViewController {
         
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(self.view.safeAreaLayoutGuide).inset(32)
-            make.leading.equalTo(viewPadding)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(16)
         }
         
         minimumLabel.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(32)
-            make.leading.equalTo(viewPadding)
+            make.leading.equalTo(titleLabel)
         }
         
         slashLabel.snp.makeConstraints { make in
@@ -81,11 +83,11 @@ class PriceGraphViewController: UIViewController {
         
         let descriptionLabel = priceLabel("평균 1박 요금은 ₩165,556 입니다.")
         descriptionLabel.font = smallFont
-        descriptionLabel.textColor = UIColor(named: "Grey3")
+        descriptionLabel.textColor = UIColor.gray3
         
         descriptionLabel.snp.makeConstraints { make in
             make.top.equalTo(minimumLabel.snp.bottom).offset(8)
-            make.leading.equalTo(viewPadding)
+            make.leading.equalTo(titleLabel)
         }
         
         graph.drawGraph(distribution: [0.3, 0.4, 0.9, 0.65, 1, 0.65, 0.8, 0.8, 0.75, 0.8, 0.25, 0.5, 0.2, 0.05, 0.23, 0.4, 0.2, 0.0, 0.5, 0.1])
@@ -93,8 +95,8 @@ class PriceGraphViewController: UIViewController {
         
         graph.snp.makeConstraints { make in
             make.top.equalTo(descriptionLabel.snp.bottom).offset(48)
-            make.leading.equalTo(viewPadding)
-            make.trailing.equalTo(-1*viewPadding)
+            make.leading.equalTo(titleLabel)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(16)
             make.height.equalTo(100)
         }
         
@@ -110,14 +112,14 @@ class PriceGraphViewController: UIViewController {
 
         semanticGrayView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
-            $0.leading.equalTo(viewPadding)
+            $0.leading.equalTo(graph)
             self.editableWidth = $0.width.equalTo(self.graph.frame.width * CGFloat(self.slider.value)).constraint
         }
         
         slider.snp.makeConstraints { make in
             make.top.equalTo(self.graph.snp.bottom)
-            make.leading.equalTo(viewPadding)
-            make.trailing.equalTo(-1 * viewPadding)
+            make.leading.equalTo(graph)
+            make.trailing.equalTo(graph)
         }
         
         slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -42,6 +42,7 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         graph.drawGraph(distribution: [0.3, 0.4, 0.9, 0.65, 1, 0.65, 0.8, 0.8, 0.75, 0.8, 0.25, 0.5, 0.2, 0.05, 0.23, 0.4, 0.2, 0.0, 0.5, 0.1])
         view.backgroundColor = .systemBackground
         navigationItem.title = "숙소 찾기"
+        self.toolbarItems = setUpToolBarItems()
     }
     
     func layout() {
@@ -125,10 +126,23 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         return label
     }
     
+    private func setUpToolBarItems() -> [UIBarButtonItem] {
+        let spacing = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        let skipButton = UIBarButtonItem(title: "건너뛰기", style: .plain, target: self, action: #selector(nextButtonTouchUpInside(_:)))
+        let nextButton = UIBarButtonItem(title: "다음", style: .plain, target: self, action: #selector(nextButtonTouchUpInside(_:)))
+        nextButton.isEnabled = true
+        return [skipButton, spacing, nextButton]
+    }
+    
     @objc func sliderValueChanged(_ sender: CustomRangeSlider) {
         self.editableLeading?.update(inset: sender.lowerValue * graph.frame.width)
         self.editableTrailing?.update(inset: (sender.maximumValue - sender.upperValue) * graph.frame.width)
         super.updateViewConstraints()
+    }
+    
+    @objc func nextButtonTouchUpInside(_ sender: UIBarButtonItem) {
+        let nextVC = SearchHeadCountViewController()
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -13,7 +13,8 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
     private let viewPadding: CGFloat = 16
     
     private let graph = ColumnGraphView()
-    private var editableWidth: Constraint?
+    private var editableLeading: Constraint?
+    private var editableTrailing: Constraint?
     private var slider = CustomRangeSlider(frame: .zero)
     
     // 그래프의 선택되지 않는 희미한 부분
@@ -85,15 +86,16 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
             make.height.equalTo(100)
         }
         
+        graph.layoutIfNeeded()
+        
         lightGrayView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
         semanticGrayView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
-            $0.leading.equalTo(graph)
-//            self.editableWidth = $0.width.equalTo(self.graph.frame.width * CGFloat(self.slider.value)).constraint
-            self.editableWidth = $0.width.equalTo(self.graph.frame.width).constraint
+            self.editableLeading = $0.leading.equalTo(graph).inset(graph.frame.width * slider.lowerValue).constraint
+            self.editableTrailing = $0.trailing.equalTo(graph).inset(graph.frame.width * (slider.maximumValue - slider.upperValue)).constraint
         }
         
         slider.snp.makeConstraints { make in
@@ -110,7 +112,7 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
     }
     
     func bind() {
-//        slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)
+        slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)
     }
     
     private func priceLabel(_ labelText: String) -> UILabel {
@@ -123,10 +125,9 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         return label
     }
     
-    @objc func sliderValueChanged(_ sender: UISlider) {
-//        let width = self.graph.frame.width * CGFloat(slider.value)
-        let width = self.graph.frame.width
-        self.editableWidth?.update(offset: width)
+    @objc func sliderValueChanged(_ sender: CustomRangeSlider) {
+        self.editableLeading?.update(inset: sender.lowerValue * graph.frame.width)
+        self.editableTrailing?.update(inset: (sender.maximumValue - sender.upperValue) * graph.frame.width)
         super.updateViewConstraints()
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -5,11 +5,10 @@
 //  Created by 백상휘 on 2022/05/31.
 //
 
-import Foundation
 import UIKit
 import SnapKit
 
-class PriceGraphViewController: UIViewController {
+class PriceGraphViewController: BackgroundViewController, CommonViewControllerProtocol {
     
     private let viewPadding: CGFloat = 16
     
@@ -19,96 +18,82 @@ class PriceGraphViewController: UIViewController {
         let slider = UISlider()
         slider.minimumValue = 0
         slider.maximumValue = 1
-        slider.thumbTintColor = UIColor.gray3
-        slider.tintColor = UIColor.gray3
+        slider.thumbTintColor = UIColor.getGrayScale(.Grey3)
+        slider.tintColor = UIColor.getGrayScale(.Grey3)
         return slider
     }()
-    
-    private lazy var priceLabel: (String) -> UILabel = {
-        let label = UILabel()
-        label.text = $0
-        label.textColor = UIColor.gray1
-        self.view.addSubview(label)
-        return label
-    }
     
     // 그래프의 선택되지 않는 희미한 부분
     private let lightGrayView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.gray4
+        view.backgroundColor = UIColor.getGrayScale(.Grey4)
         return view
     }()
     
     // 그래프에서 선택되는 진한 부분
     let semanticGrayView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.gray3
+        view.backgroundColor = UIColor.getGrayScale(.Grey3)
         return view
     }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        attribute()
+        layout()
+        bind()
+    }
+    
+    func attribute() {
+        graph.drawGraph(distribution: [0.3, 0.4, 0.9, 0.65, 1, 0.65, 0.8, 0.8, 0.75, 0.8, 0.25, 0.5, 0.2, 0.05, 0.23, 0.4, 0.2, 0.0, 0.5, 0.1])
+        view.backgroundColor = .systemBackground
+        navigationItem.title = "숙소 찾기"
+    }
+    
+    func layout() {
         let titleLabel = priceLabel("가격 범위")
-        let minimumLabel = priceLabel("\(NumberFormatter.localizedString(from: 11000, number: .currency))")
-        let slashLabel = priceLabel("-")
-        let maximumLabel = priceLabel("\(NumberFormatter.localizedString(from: 1000000, number: .currency))")
+        let priceRangeLabel = priceLabel("₩\(NumberFormatter.localizedString(from: 11000, number: .decimal)) - ₩\(NumberFormatter.localizedString(from: 1000000, number: .decimal))")
         
-        let largeFont = UIFont(name: titleLabel.font.fontName, size: 17)
-        let smallFont = UIFont(name: titleLabel.font.fontName, size: 12)
+        let labelFont: (CGFloat) -> UIFont? = { size in
+            UIFont(name: titleLabel.font.fontName, size: size)
+        }
         
-        titleLabel.font = largeFont
-        minimumLabel.font = largeFont
-        maximumLabel.font = largeFont
+        titleLabel.font = labelFont(17)
+        priceRangeLabel.font = labelFont(17)
         
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(self.view.safeAreaLayoutGuide).inset(32)
-            make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(16)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide).offset(viewPadding)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(viewPadding)
         }
         
-        minimumLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(32)
-            make.leading.equalTo(titleLabel)
-        }
-        
-        slashLabel.snp.makeConstraints { make in
-            make.leading.equalTo(minimumLabel.snp.trailing).offset(8)
-            make.centerY.equalTo(minimumLabel)
-        }
-        
-        maximumLabel.snp.makeConstraints { make in
-            make.leading.equalTo(slashLabel.snp.trailing).offset(8)
-            make.centerY.equalTo(minimumLabel)
+        priceRangeLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(viewPadding)
+            make.leading.trailing.equalTo(titleLabel)
         }
         
         let descriptionLabel = priceLabel("평균 1박 요금은 ₩165,556 입니다.")
-        descriptionLabel.font = smallFont
-        descriptionLabel.textColor = UIColor.gray3
-        
+        descriptionLabel.font = labelFont(12)
+        descriptionLabel.textColor = UIColor.getGrayScale(.Grey3)
         descriptionLabel.snp.makeConstraints { make in
-            make.top.equalTo(minimumLabel.snp.bottom).offset(8)
-            make.leading.equalTo(titleLabel)
+            make.top.equalTo(priceRangeLabel.snp.bottom).offset(8)
+            make.leading.trailing.equalTo(titleLabel)
         }
         
-        graph.drawGraph(distribution: [0.3, 0.4, 0.9, 0.65, 1, 0.65, 0.8, 0.8, 0.75, 0.8, 0.25, 0.5, 0.2, 0.05, 0.23, 0.4, 0.2, 0.0, 0.5, 0.1])
         view.addSubview(graph)
+        graph.addSubview(lightGrayView)
+        graph.addSubview(semanticGrayView)
+        view.addSubview(slider)
         
         graph.snp.makeConstraints { make in
             make.top.equalTo(descriptionLabel.snp.bottom).offset(48)
-            make.leading.equalTo(titleLabel)
-            make.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(16)
+            make.leading.trailing.equalTo(titleLabel)
             make.height.equalTo(100)
         }
-        
-        graph.addSubview(lightGrayView)
         
         lightGrayView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-        
-        view.addSubview(slider)
-        
-        graph.addSubview(semanticGrayView)
 
         semanticGrayView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
@@ -118,11 +103,22 @@ class PriceGraphViewController: UIViewController {
         
         slider.snp.makeConstraints { make in
             make.top.equalTo(self.graph.snp.bottom)
-            make.leading.equalTo(graph)
-            make.trailing.equalTo(graph)
+            make.leading.trailing.equalTo(graph)
         }
-        
+    }
+    
+    func bind() {
         slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)
+    }
+    
+    private func priceLabel(_ labelText: String) -> UILabel {
+        let label = UILabel()
+        label.text = labelText
+        label.textColor = UIColor.getGrayScale(.Grey1)
+        label.textAlignment = .left
+        label.adjustsFontSizeToFitWidth = true
+        view.addSubview(label)
+        return label
     }
     
     @objc func sliderValueChanged(_ sender: UISlider) {

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -7,25 +7,42 @@
 
 import Foundation
 import UIKit
+import SnapKit
 
 class PriceGraphViewController: UIViewController {
     
+    private let viewPadding: CGFloat = 16
+    
     private let graph = ColumnGraphView()
+    private var editableWidth: Constraint?
     private let slider: UISlider = {
         let slider = UISlider()
         slider.minimumValue = 0
-        slider.maximumValue = 100
+        slider.maximumValue = 1
+        slider.thumbTintColor = UIColor(named: "Grey3")
+        slider.setThumbImage(UIImage(named: "PauseCircle"), for: .normal)
         return slider
     }()
     
-    private let priceFont = UIFont(name: "SF Pro Display", size: 17)
     private lazy var priceLabel: (String) -> UILabel = {
         let label = UILabel()
         label.text = $0
-        label.font = self.priceFont
+        label.textColor = UIColor(named: "Grey1")
         self.view.addSubview(label)
         return label
     }
+    
+    private let lightGrayView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "Grey4")
+        return view
+    }()
+    
+    let semanticGrayView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "Grey3")
+        return view
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,14 +52,21 @@ class PriceGraphViewController: UIViewController {
         let slashLabel = priceLabel("-")
         let maximumLabel = priceLabel("\(NumberFormatter.localizedString(from: 1000000, number: .currency))")
         
+        let largeFont = UIFont(name: titleLabel.font.fontName, size: 17)
+        let smallFont = UIFont(name: titleLabel.font.fontName, size: 12)
+        
+        titleLabel.font = largeFont
+        minimumLabel.font = largeFont
+        maximumLabel.font = largeFont
+        
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(self.view.safeAreaLayoutGuide).inset(32)
-            make.leading.equalTo(16)
+            make.leading.equalTo(viewPadding)
         }
         
         minimumLabel.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(32)
-            make.leading.equalTo(16)
+            make.leading.equalTo(viewPadding)
         }
         
         slashLabel.snp.makeConstraints { make in
@@ -56,31 +80,53 @@ class PriceGraphViewController: UIViewController {
         }
         
         let descriptionLabel = priceLabel("평균 1박 요금은 ₩165,556 입니다.")
-        descriptionLabel.font = UIFont(name: descriptionLabel.font.fontName, size: 12)
-        descriptionLabel.textColor = UIColor(named: "Gray3")
+        descriptionLabel.font = smallFont
+        descriptionLabel.textColor = UIColor(named: "Grey3")
         
         descriptionLabel.snp.makeConstraints { make in
             make.top.equalTo(minimumLabel.snp.bottom).offset(8)
-            make.leading.equalTo(16)
+            make.leading.equalTo(viewPadding)
         }
         
-        graph.drawGraph(distribution: [30, 40, 90, 65, 100, 65, 80, 80, 75, 80, 25, 50, 20, 5, 23, 40, 20, 0, 5, 10])
+        graph.drawGraph(distribution: [0.3, 0.4, 0.9, 0.65, 1, 0.65, 0.8, 0.8, 0.75, 0.8, 0.25, 0.5, 0.2, 0.05, 0.23, 0.4, 0.2, 0.0, 0.5, 0.1])
         view.addSubview(graph)
         
         graph.snp.makeConstraints { make in
             make.top.equalTo(descriptionLabel.snp.bottom).offset(48)
-            make.leading.equalTo(16)
-            make.trailing.equalTo(-16)
+            make.leading.equalTo(viewPadding)
+            make.trailing.equalTo(-1*viewPadding)
             make.height.equalTo(100)
+        }
+        
+        graph.addSubview(lightGrayView)
+        
+        lightGrayView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         view.addSubview(slider)
         
+        graph.addSubview(semanticGrayView)
+
+        semanticGrayView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(viewPadding)
+            self.editableWidth = $0.width.equalTo(self.graph.frame.width * CGFloat(self.slider.value)).constraint
+        }
+        
         slider.snp.makeConstraints { make in
             make.top.equalTo(self.graph.snp.bottom)
-            make.leading.equalTo(16)
-            make.trailing.equalTo(-16)
+            make.leading.equalTo(viewPadding)
+            make.trailing.equalTo(-1 * viewPadding)
         }
+        
+        slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)
+    }
+    
+    @objc func sliderValueChanged(_ sender: UISlider) {
+        let width = self.graph.frame.width * CGFloat(slider.value)
+        self.editableWidth?.update(offset: width)
+        super.updateViewConstraints()
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -1,0 +1,87 @@
+//
+//  PriceGraphViewController.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/31.
+//
+
+import Foundation
+import UIKit
+
+class PriceGraphViewController: UIViewController {
+    
+    private let graph = ColumnGraphView()
+    private let slider: UISlider = {
+        let slider = UISlider()
+        slider.minimumValue = 0
+        slider.maximumValue = 100
+        return slider
+    }()
+    
+    private let priceFont = UIFont(name: "SF Pro Display", size: 17)
+    private lazy var priceLabel: (String) -> UILabel = {
+        let label = UILabel()
+        label.text = $0
+        label.font = self.priceFont
+        self.view.addSubview(label)
+        return label
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let titleLabel = priceLabel("가격 범위")
+        let minimumLabel = priceLabel("\(NumberFormatter.localizedString(from: 11000, number: .currency))")
+        let slashLabel = priceLabel("-")
+        let maximumLabel = priceLabel("\(NumberFormatter.localizedString(from: 1000000, number: .currency))")
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide).inset(32)
+            make.leading.equalTo(16)
+        }
+        
+        minimumLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(32)
+            make.leading.equalTo(16)
+        }
+        
+        slashLabel.snp.makeConstraints { make in
+            make.leading.equalTo(minimumLabel.snp.trailing).offset(8)
+            make.centerY.equalTo(minimumLabel)
+        }
+        
+        maximumLabel.snp.makeConstraints { make in
+            make.leading.equalTo(slashLabel.snp.trailing).offset(8)
+            make.centerY.equalTo(minimumLabel)
+        }
+        
+        let descriptionLabel = priceLabel("평균 1박 요금은 ₩165,556 입니다.")
+        descriptionLabel.font = UIFont(name: descriptionLabel.font.fontName, size: 12)
+        descriptionLabel.textColor = UIColor(named: "Gray3")
+        
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(minimumLabel.snp.bottom).offset(8)
+            make.leading.equalTo(16)
+        }
+        
+        graph.drawGraph(distribution: [30, 40, 90, 65, 100, 65, 80, 80, 75, 80, 25, 50, 20, 5, 23, 40, 20, 0, 5, 10])
+        view.addSubview(graph)
+        
+        graph.snp.makeConstraints { make in
+            make.top.equalTo(descriptionLabel.snp.bottom).offset(48)
+            make.leading.equalTo(16)
+            make.trailing.equalTo(-16)
+            make.height.equalTo(100)
+        }
+        
+        view.addSubview(slider)
+        
+        slider.snp.makeConstraints { make in
+            make.top.equalTo(self.graph.snp.bottom)
+            make.leading.equalTo(16)
+            make.trailing.equalTo(-16)
+        }
+    }
+}
+
+

--- a/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/Graph/View/PriceGraphViewController.swift
@@ -14,14 +14,15 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
     
     private let graph = ColumnGraphView()
     private var editableWidth: Constraint?
-    private let slider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = 0
-        slider.maximumValue = 1
-        slider.thumbTintColor = UIColor.getGrayScale(.Grey3)
-        slider.tintColor = UIColor.getGrayScale(.Grey3)
-        return slider
-    }()
+//    private let slider: UISlider = {
+//        let slider = UISlider()
+//        slider.minimumValue = 0
+//        slider.maximumValue = 1
+//        slider.thumbTintColor = UIColor.getGrayScale(.Grey3)
+//        slider.tintColor = UIColor.getGrayScale(.Grey3)
+//        return slider
+//    }()
+    private var slider = CustomRangeSlider(frame: .zero)
     
     // 그래프의 선택되지 않는 희미한 부분
     private let lightGrayView: UIView = {
@@ -83,6 +84,8 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         view.addSubview(graph)
         graph.addSubview(lightGrayView)
         graph.addSubview(semanticGrayView)
+        
+        slider.backgroundColor = .red
         view.addSubview(slider)
         
         graph.snp.makeConstraints { make in
@@ -98,17 +101,26 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
         semanticGrayView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
             $0.leading.equalTo(graph)
-            self.editableWidth = $0.width.equalTo(self.graph.frame.width * CGFloat(self.slider.value)).constraint
+//            self.editableWidth = $0.width.equalTo(self.graph.frame.width * CGFloat(self.slider.value)).constraint
+            self.editableWidth = $0.width.equalTo(self.graph.frame.width).constraint
         }
         
         slider.snp.makeConstraints { make in
             make.top.equalTo(self.graph.snp.bottom)
             make.leading.trailing.equalTo(graph)
+            make.height.equalTo(31)
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        print(slider.frame)
+        slider.updateLayerFrames()
+        slider.layoutIfNeeded()
+    }
+    
     func bind() {
-        slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)
+//        slider.addTarget(self, action: #selector(sliderValueChanged(_:)), for: .valueChanged)
     }
     
     private func priceLabel(_ labelText: String) -> UILabel {
@@ -122,7 +134,8 @@ class PriceGraphViewController: BackgroundViewController, CommonViewControllerPr
     }
     
     @objc func sliderValueChanged(_ sender: UISlider) {
-        let width = self.graph.frame.width * CGFloat(slider.value)
+//        let width = self.graph.frame.width * CGFloat(slider.value)
+        let width = self.graph.frame.width
         self.editableWidth?.update(offset: width)
         super.updateViewConstraints()
     }

--- a/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
@@ -15,24 +15,20 @@ class CalendarModel {
     
     private var baseDate: Date {
         didSet {
-            days = generateDaysInMonth(for: baseDate)
+            month = generate12month(for: baseDate)
             self.onUpdate()
         }
     }
     
-    lazy var days = generateDaysInMonth(for: baseDate)
+    lazy var month = generate12month(for: baseDate)
     
-    private var numberOfWeeksInBaseDate: Int {
+    var numberOfWeeksInBaseDate: Int {
       calendar.range(of: .weekOfMonth, in: .month, for: baseDate)?.count ?? 0
     }
     
     var onUpdate: () -> Void = { }
     
-    let calendar: Calendar = {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale(identifier: "ko_kr")
-        return calendar
-    }()
+    let calendar: Calendar = Calendar.current
     
     private lazy var dateFormatter: DateFormatter = {
       let dateFormatter = DateFormatter()
@@ -42,38 +38,54 @@ class CalendarModel {
     
     init(baseDate: Date) {
         self.baseDate = baseDate
+
     }
     
-    private func makeMonthMetadata(for baseDate: Date) -> Result<MonthMetadata, CalendarDateError> {
+    func generate12month(for baseDate: Date) -> [Month] {
+        
+        var year: [Month] = []
+        for addMonth in stride(from: 0, to: 11, by: 1) {
+            if let month = calendar.date(byAdding: .month, value: addMonth, to: baseDate) {
+                year.append(generateDaysInMonth(for: month))
+            }
+        }
+        // 그 이중 배열을 내보냄 근데 그 기준일이 언제임, 그 기준일을 가지고 제일 처음에 보여줄 달을 짜는 로직도 힘겹겠네.. 가장 처음 지금 있는 달이 나와야 할테니까...
+        return year
+    }
+    
+    private func generateMonthMetadata(for baseDate: Date) -> Result<MonthMetadata, CalendarDateError> {
         guard let daysCountInMonth = calendar.range(of: .day, in: .month, for: baseDate)?.count,
               let firstDayInMonth = calendar.date(
-                from: calendar.dateComponents([.year, .month, .hour], from: baseDate)) else {
+                from: calendar.dateComponents([.year, .month], from: baseDate)) else {
                     return .failure(CalendarDateError.monthMetadataError)
                 }
         let firstDayWeekday = calendar.component(.weekday, from: firstDayInMonth)
         return .success(MonthMetadata(numberOfDays: daysCountInMonth, firstDay: firstDayInMonth, firstDayWeekday: firstDayWeekday))
     }
     
-    func generateDaysInMonth(for baseDate: Date) -> [Day] {
-        switch makeMonthMetadata(for: baseDate) {
+    private func generateDaysInMonth(for baseDate: Date) -> Month {
+        switch generateMonthMetadata(for: baseDate) {
         case .success(let metadata):
             let daysCountInMonth = metadata.numberOfDays
             let offsetInInitailRow = metadata.firstDayWeekday
             let firstDayOfMonth = metadata.firstDay
             
-            let days: [Day] = (1..<daysCountInMonth).map { day in
-                let dayOffset = day - offsetInInitailRow
-                return generateDay(offsetBy: dayOffset, for: firstDayOfMonth)
+            let days: [Day] = (1..<daysCountInMonth + offsetInInitailRow).map { day in
+                let isWithinDisplayedMonth = day >= offsetInInitailRow
+                let dayOffset = isWithinDisplayedMonth ? day - offsetInInitailRow : -(offsetInInitailRow - day)
+                return generateDay(offsetBy: dayOffset,
+                                   for: firstDayOfMonth,
+                                   isWithinDisplayedMonth: isWithinDisplayedMonth)
             }
-            return days
+            return Month(date: baseDate, result: days)
         case .failure(let error):
-            dump(error)
-            return []
+            fatalError("failed making month ==> \(dump(error))")
         }
     }
     
     private func generateDay(offsetBy dayOffset: Int,
-                             for baseDate: Date)  -> Day {
+                             for baseDate: Date,
+                             isWithinDisplayedMonth: Bool)  -> Day {
         let date = calendar.date(byAdding: .day,
                                  value: dayOffset,
                                  to: baseDate) ?? baseDate
@@ -81,15 +93,46 @@ class CalendarModel {
             return Day(date: date,
                        number: dateFormatter.string(from: date),
                        isSelected: calendar.isDate(date,
-                                                   inSameDayAs: selectedDate))
+                                                   inSameDayAs: selectedDate),
+                        isWithInDisplayedMonth: isWithinDisplayedMonth)
         } else {
             return Day(date: date,
                        number: dateFormatter.string(from: date),
-                       isSelected: false)
+                       isSelected: false,
+                       isWithInDisplayedMonth: isWithinDisplayedMonth)
         }
     }
 }
 
 enum CalendarDateError: Error {
     case monthMetadataError
+}
+
+extension CalendarModel {
+    func shinghaSayMakeDays(for baseDate: Date) -> [Date?] {
+        let component = calendar.dateComponents([.year, .month], from: baseDate)
+        guard let firstDate = calendar.date(from: component),
+              let nextMonthDate = calendar.date(byAdding: .month, value: 1, to: firstDate), // 7월 1일
+              let lastDate = calendar.date(byAdding: .day, value: -1, to: nextMonthDate) else {
+                  return []
+              }
+        let startComponent = calendar.dateComponents([.day, .weekday], from: firstDate)
+        let lastComponent = calendar.dateComponents([.day, .weekday], from: lastDate)
+        guard let lastday = lastComponent.day,
+              let startWeekDay = startComponent.weekday,
+              let lastWeekDay = lastComponent.weekday else {
+                  return []
+              }
+        var dates: [Date?] = (0..<lastday).map { addDay in
+            calendar.date(byAdding: .day, value: addDay, to: firstDate)
+        }
+        (0..<startWeekDay - 1).forEach { _ in dates.insert(nil, at: 0) }
+        (lastWeekDay - 1..<6).forEach { _ in dates.append(nil) }
+        return dates
+    }
+}
+
+struct Month {
+    let date: Date
+    let result: [Day]
 }

--- a/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/CalendarModel.swift
@@ -1,0 +1,95 @@
+//
+//  CalendarModel.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/06/01.
+//
+
+import Foundation
+
+class CalendarModel {
+    
+    let selectedDateChaged: (Date) -> Void = { _ in }
+    
+    var selectedDate: Date?
+    
+    private var baseDate: Date {
+        didSet {
+            days = generateDaysInMonth(for: baseDate)
+            self.onUpdate()
+        }
+    }
+    
+    lazy var days = generateDaysInMonth(for: baseDate)
+    
+    private var numberOfWeeksInBaseDate: Int {
+      calendar.range(of: .weekOfMonth, in: .month, for: baseDate)?.count ?? 0
+    }
+    
+    var onUpdate: () -> Void = { }
+    
+    let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_kr")
+        return calendar
+    }()
+    
+    private lazy var dateFormatter: DateFormatter = {
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "d"
+      return dateFormatter
+    }()
+    
+    init(baseDate: Date) {
+        self.baseDate = baseDate
+    }
+    
+    private func makeMonthMetadata(for baseDate: Date) -> Result<MonthMetadata, CalendarDateError> {
+        guard let daysCountInMonth = calendar.range(of: .day, in: .month, for: baseDate)?.count,
+              let firstDayInMonth = calendar.date(
+                from: calendar.dateComponents([.year, .month, .hour], from: baseDate)) else {
+                    return .failure(CalendarDateError.monthMetadataError)
+                }
+        let firstDayWeekday = calendar.component(.weekday, from: firstDayInMonth)
+        return .success(MonthMetadata(numberOfDays: daysCountInMonth, firstDay: firstDayInMonth, firstDayWeekday: firstDayWeekday))
+    }
+    
+    func generateDaysInMonth(for baseDate: Date) -> [Day] {
+        switch makeMonthMetadata(for: baseDate) {
+        case .success(let metadata):
+            let daysCountInMonth = metadata.numberOfDays
+            let offsetInInitailRow = metadata.firstDayWeekday
+            let firstDayOfMonth = metadata.firstDay
+            
+            let days: [Day] = (1..<daysCountInMonth).map { day in
+                let dayOffset = day - offsetInInitailRow
+                return generateDay(offsetBy: dayOffset, for: firstDayOfMonth)
+            }
+            return days
+        case .failure(let error):
+            dump(error)
+            return []
+        }
+    }
+    
+    private func generateDay(offsetBy dayOffset: Int,
+                             for baseDate: Date)  -> Day {
+        let date = calendar.date(byAdding: .day,
+                                 value: dayOffset,
+                                 to: baseDate) ?? baseDate
+        if let selectedDate = selectedDate {
+            return Day(date: date,
+                       number: dateFormatter.string(from: date),
+                       isSelected: calendar.isDate(date,
+                                                   inSameDayAs: selectedDate))
+        } else {
+            return Day(date: date,
+                       number: dateFormatter.string(from: date),
+                       isSelected: false)
+        }
+    }
+}
+
+enum CalendarDateError: Error {
+    case monthMetadataError
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/LocationModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/LocationModel.swift
@@ -8,30 +8,52 @@
 import Foundation
 import CloudKit
 
-struct CityInfomation {
+protocol CityInformation {
+    var destination: String { get }
+}
+
+struct PopularCityInfomation: CityInformation {
     let destination: String
     let distance: String
     let imageUrl: String
 }
 
+struct NearbyCityInformation: CityInformation {
+    let destination: String
+}
+
 class LocationModel {
-    private var model: [CityInfomation] = []
+    private var popularDTO: [PopularCityInfomation] = []
+    private var nearbyDTO: [NearbyCityInformation] = []
+    private var locationViewMode: LocationViewMode = .popular
     
-    subscript(index: Int) -> CityInfomation? {
+    private var dtoOnMode: [CityInformation] {
+        locationViewMode == .popular ? popularDTO : nearbyDTO
+    }
+        
+    subscript(index: Int) -> CityInformation? {
         get {
-            if 0 <= index, index < model.count {
-                return model[index]
+            if 0 <= index, index < dtoOnMode.count {
+                return dtoOnMode[index]
             }
             return nil
         }
     }
     
     init() {
-        model = make8CitiesInfo()
+        popularDTO = make8CitiesInfo()
+        nearbyDTO = makeTenNearbyCitiesInfo()
     }
     
+    func changeMode(_ mode: LocationViewMode) {
+        self.locationViewMode = mode
+    }
     
-    private func make8CitiesInfo() -> [CityInfomation] {
+    func getCount() -> Int {
+        dtoOnMode.count
+    }
+    
+    private func make8CitiesInfo() -> [PopularCityInfomation] {
         let locations: [String] = [
             "서울", "광주", "의정부시", "수원시",
             "대구", "울산", "대전", "부천시"
@@ -41,12 +63,24 @@ class LocationModel {
             "차로 3.5시간 거리", "차로 4.5시간 거리", "차로 2시간 거리", "차로 30분 거리"
         ]
         
-        return  locations.enumerated().map { index, element in
-            CityInfomation(destination: element, distance: spandings[index], imageUrl: "")
+        return locations.enumerated().map { index, element in
+            PopularCityInfomation(destination: element, distance: spandings[index], imageUrl: "")
         }
     }
     
-    func getCount() -> Int {
-        model.count
+    private func makeTenNearbyCitiesInfo() -> [NearbyCityInformation] {
+        let locations: [String] = [
+            "양재동, 서초구, 서울특별시", "양재역 사거리, 양재1동", "서울특별시 양재2동 시민의숲앞", "서울특별시 양재2동 양재IC", "영국 런던 스미스씨 댁",
+            "대구", "울산", "대전", "부천시", "의정부 부대찌개 거리"
+        ]
+        
+        return locations.map {
+            NearbyCityInformation(destination: $0)
+        }
+    }
+    
+    enum LocationViewMode {
+        case popular
+        case nearby
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/Model/LocationModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/LocationModel.swift
@@ -1,0 +1,52 @@
+//
+//  LocationModel.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/05/30.
+//
+
+import Foundation
+import CloudKit
+
+struct CityInfomation {
+    let destination: String
+    let distance: String
+    let imageUrl: String
+}
+
+class LocationModel {
+    private var model: [CityInfomation] = []
+    
+    subscript(index: Int) -> CityInfomation? {
+        get {
+            if 0 <= index, index < model.count {
+                return model[index]
+            }
+            return nil
+        }
+    }
+    
+    init() {
+        model = make8CitiesInfo()
+    }
+    
+    
+    private func make8CitiesInfo() -> [CityInfomation] {
+        let locations: [String] = [
+            "서울", "광주", "의정부시", "수원시",
+            "대구", "울산", "대전", "부천시"
+        ]
+        let spandings: [String] = [
+            "차로 30분 거리", "차로 4시간 거리", "차로 30분 거리", "차로 45분 거리",
+            "차로 3.5시간 거리", "차로 4.5시간 거리", "차로 2시간 거리", "차로 30분 거리"
+        ]
+        
+        return  locations.enumerated().map { index, element in
+            CityInfomation(destination: element, distance: spandings[index], imageUrl: "")
+        }
+    }
+    
+    func getCount() -> Int {
+        model.count
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/MonthMetadata.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/MonthMetadata.swift
@@ -1,0 +1,14 @@
+//
+//  MonthMetadata.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/06/01.
+//
+
+import Foundation
+
+struct MonthMetadata {
+    let numberOfDays: Int
+    let firstDay: Date
+    let firstDayWeekday: Int
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/ReservationModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/ReservationModel.swift
@@ -1,0 +1,18 @@
+//
+//  SearchModel.swift
+//  Airbnb
+//
+//  Created by YEONGJIN JANG on 2022/05/23.
+//
+
+import Foundation
+
+//TODO: - 외부에서 값 변경 하지 못하게 변수 접근제한자 설정
+class ReservationModel {
+    var location: String?
+    var checkInDate: String?
+    var checkOutDate: String?
+    var minCharge: Int?
+    var maxCharge: Int?
+    var headcount: Int?
+}

--- a/iOS/Airbnb/Airbnb/Search/Model/SearchCalendarModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/SearchCalendarModel.swift
@@ -9,6 +9,26 @@ import Foundation
 
 class SearchCalendarModel {
     
+    private(set) var resultArray: [CalendarResult] = [] {
+        didSet {
+            self.onUpdateAYear()
+        }
+    }
+    
+    private(set) var date = Date()
+    
+    var count: Int { resultArray.count }
+    
+    var onUpdateAYear: () -> Void = { }
+    
+    func make12month(baseDate: Date) {
+        for _ in 0..<12 {
+            let nextMonthResult = getNextMonthDays(from: baseDate)
+            self.resultArray.append(nextMonthResult)
+            self.date = nextMonthResult.date
+        }
+    }
+    
     private(set) var localCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
         calendar.locale = Locale(identifier: "ko_kr")
@@ -47,7 +67,7 @@ class SearchCalendarModel {
         }
         
         var dateComponent = localCalendar.dateComponents([.year,.month,.day,.hour], from: dateMonthMoved)
-        dateComponent.day = 2
+//        dateComponent.day = 2
         dateComponent.hour = 0
         
         guard

--- a/iOS/Airbnb/Airbnb/Search/Model/SearchModel.swift
+++ b/iOS/Airbnb/Airbnb/Search/Model/SearchModel.swift
@@ -1,8 +1,0 @@
-//
-//  SearchModel.swift
-//  Airbnb
-//
-//  Created by YEONGJIN JANG on 2022/05/23.
-//
-
-import Foundation

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -9,10 +9,8 @@ import UIKit
 import SnapKit
 
 class LocationViewController: BackgroundViewController, CommonViewControllerProtocol {
-    
-    private let locations: [String] = [
-        "서울", "광주", "의정부시", "수원시", "대구", "울산", "대전", "부천시"
-    ]
+     
+    let model = LocationModel()
     
     private let searchController: UISearchController = {
         let searchController = UISearchController(searchResultsController: nil)
@@ -26,9 +24,11 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         return searchController
     }()
         
-    private var nearbyLoactionView: UICollectionView = {
+    lazy var nearbyLoactionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
+        layout.itemSize = CGSize(width: UIScreen.main.bounds.width, height: 64)
+        
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(LocationCollectionViewCell.self, forCellWithReuseIdentifier: LocationCollectionViewCell.reuseIdentifier)
         collectionView.register(HeaderReusableView.self,
@@ -36,7 +36,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         return collectionView
     }()
     
-    lazy var removeSearchTextField: UIBarButtonItem = {
+    lazy var searchInitializeButton: UIBarButtonItem = {
         let barButton = UIBarButtonItem(title: "지우기", style: .done,
                                         target: self, action: #selector(self.clearSearchField(_:)))
         barButton.tintColor = .gray
@@ -49,6 +49,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         navigationItem.title = "숙소 찾기"
         super.setUpNavigationAppearance()
         view.backgroundColor = .systemBackground
+        self.navigationController?.isToolbarHidden = false
     }
     
     func layout() {
@@ -106,31 +107,26 @@ extension LocationViewController: UISearchBarDelegate, UITextFieldDelegate, UISe
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        !searchText.isEmpty
-        ? (navigationItem.rightBarButtonItem = removeSearchTextField)
-        : (navigationItem.rightBarButtonItem = nil)
+        navigationItem.rightBarButtonItem = !searchText.isEmpty ? searchInitializeButton : nil
     }
 }
 
 extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        locations.count
+        model.getCount()
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = nearbyLoactionView.dequeueReusableCell(withReuseIdentifier: LocationCollectionViewCell.reuseIdentifier, for: indexPath) as? LocationCollectionViewCell else {
             return UICollectionViewCell()
         }
-        cell.cityName.text = locations[indexPath.row]
-        cell.spendingTime.text = locations[indexPath.row]
+        guard let item = model[indexPath.row] else {
+            return UICollectionViewCell()
+        }
+        cell.cityName.text = item.destination
+        cell.spendingTime.text = item.distance
         return cell
     }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.width, height: 64)
-    }
-    
-    
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) ->
     UICollectionReusableView {

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -27,8 +27,6 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
     lazy var nearbyLoactionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.itemSize = CGSize(width: UIScreen.main.bounds.width, height: 64)
-        
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(LocationCollectionViewCell.self, forCellWithReuseIdentifier: LocationCollectionViewCell.reuseIdentifier)
         collectionView.register(HeaderReusableView.self,
@@ -53,13 +51,10 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
     }
     
     func layout() {
-        let sideMargin: CGFloat = 16
         view.addSubview(nearbyLoactionView)
         
         nearbyLoactionView.snp.makeConstraints {
-            $0.top.bottom.equalTo(view)
-            $0.leading.equalTo(view).offset(sideMargin)
-            $0.trailing.equalTo(view).inset(sideMargin)
+            $0.top.trailing.leading.bottom.equalToSuperview()
         }
     }
     
@@ -142,10 +137,24 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
         }
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let reservationModel = ReservationModel()
+        guard let cell = collectionView.cellForItem(at: indexPath) as? LocationCollectionViewCell else {
+            return
+        }
+        reservationModel.location = cell.cityName.text
+        let nextVC = CalendarViewController(reservationModel: reservationModel)
+        self.navigationController?.pushViewController(nextVC, animated: true)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let sideMargin: CGFloat = 16
+        let width:CGFloat = UIScreen.main.bounds.width - sideMargin * 2
+        return CGSize(width: width, height: 64)
+    }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        let width: CGFloat = nearbyLoactionView.frame.width
         let headerViewHeight: CGFloat = ((model[0] as? PopularCityInfomation) == nil ? 0 : 78)
-        return CGSize(width: width, height: headerViewHeight)
+        return CGSize(width: 0, height: headerViewHeight)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -89,12 +89,13 @@ extension LocationViewController: UISearchBarDelegate, UITextFieldDelegate, UISe
     func updateSearchResults(for searchController: UISearchController) {
         guard let query = searchController.searchBar.text else { return }
         dump(query)
+        self.nearbyLoactionView.reloadData()
     }
-    
     
     @objc func clearSearchField(_ sender: Any) {
         searchController.searchBar.text = nil
         self.navigationItem.rightBarButtonItem = nil
+        model.changeMode(.popular)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -107,7 +108,9 @@ extension LocationViewController: UISearchBarDelegate, UITextFieldDelegate, UISe
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        navigationItem.rightBarButtonItem = !searchText.isEmpty ? searchInitializeButton : nil
+        let searchTextIsEnable = !searchText.isEmpty
+        navigationItem.rightBarButtonItem = searchTextIsEnable ? searchInitializeButton : nil
+        model.changeMode(searchTextIsEnable ? .nearby : .popular)
     }
 }
 
@@ -124,7 +127,7 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
             return UICollectionViewCell()
         }
         cell.cityName.text = item.destination
-        cell.spendingTime.text = item.distance
+        cell.spendingTime.text = (item as? PopularCityInfomation)?.distance
         return cell
     }
     
@@ -142,7 +145,7 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         let width: CGFloat = nearbyLoactionView.frame.width
-        let headerViewHeight: CGFloat = 78
+        let headerViewHeight: CGFloat = ((model[0] as? PopularCityInfomation) == nil ? 0 : 78)
         return CGSize(width: width, height: headerViewHeight)
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -47,7 +47,6 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         navigationItem.title = "숙소 찾기"
         super.setUpNavigationAppearance()
         view.backgroundColor = .systemBackground
-        self.navigationController?.isToolbarHidden = false
     }
     
     func layout() {
@@ -144,6 +143,7 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
         }
         reservationModel.location = cell.cityName.text
         let nextVC = CalendarViewController(reservationModel: reservationModel)
+        self.navigationController?.isToolbarHidden = false
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
     

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -30,7 +30,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(LocationCollectionViewCell.self, forCellWithReuseIdentifier: LocationCollectionViewCell.reuseIdentifier)
         collectionView.register(HeaderReusableView.self,
-                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderReusableView.ID)
+                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderReusableView.reuseIdentifier)
         return collectionView
     }()
     
@@ -134,7 +134,7 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
     UICollectionReusableView {
         switch kind {
         case UICollectionView.elementKindSectionHeader:
-            let headerView = nearbyLoactionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HeaderReusableView.ID, for: indexPath)
+            let headerView = nearbyLoactionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HeaderReusableView.reuseIdentifier, for: indexPath)
             return headerView
         default:
             assert(false, "header, footer, withReuseIdentifier 를 확인하세요.")

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -24,7 +24,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         return searchController
     }()
         
-    lazy var nearbyLoactionView: UICollectionView = {
+    private(set) var nearbyLoactionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -53,7 +53,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         view.addSubview(nearbyLoactionView)
         
         nearbyLoactionView.snp.makeConstraints {
-            $0.top.trailing.leading.bottom.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
     
@@ -78,7 +78,7 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        attribute()
+        navigationController?.isToolbarHidden = true
     }
     
 }
@@ -125,8 +125,8 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
         guard let item = model[indexPath.row] else {
             return UICollectionViewCell()
         }
-        cell.cityName.text = item.destination
-        cell.spendingTime.text = (item as? PopularCityInfomation)?.distance
+        
+        cell.updateInfomation(item)
         return cell
     }
     
@@ -142,14 +142,10 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let reservationModel = ReservationModel()
         guard let cell = collectionView.cellForItem(at: indexPath) as? LocationCollectionViewCell else {
             return
         }
-        let backButton = UIBarButtonItem(title: "뒤로", style: .plain,
-                                         target: self, action: nil)
-        backButton.tintColor = .gray
-        self.navigationItem.backBarButtonItem = backButton
+        let reservationModel = ReservationModel()
         reservationModel.location = cell.cityName.text
         let nextVC = CalendarViewController(reservationModel: reservationModel)
         self.navigationController?.pushViewController(nextVC, animated: true)

--- a/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/LocationViewController.swift
@@ -43,9 +43,9 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
     
     func attribute() {
         setUpDelegates()
+        navigationController?.isToolbarHidden = true
         navigationItem.searchController = searchController
         navigationItem.title = "숙소 찾기"
-        super.setUpNavigationAppearance()
         view.backgroundColor = .systemBackground
     }
     
@@ -74,6 +74,11 @@ class LocationViewController: BackgroundViewController, CommonViewControllerProt
         attribute()
         layout()
         bind()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        attribute()
     }
     
 }
@@ -141,9 +146,12 @@ extension LocationViewController: UICollectionViewDelegateFlowLayout, UICollecti
         guard let cell = collectionView.cellForItem(at: indexPath) as? LocationCollectionViewCell else {
             return
         }
+        let backButton = UIBarButtonItem(title: "뒤로", style: .plain,
+                                         target: self, action: nil)
+        backButton.tintColor = .gray
+        self.navigationItem.backBarButtonItem = backButton
         reservationModel.location = cell.cityName.text
         let nextVC = CalendarViewController(reservationModel: reservationModel)
-        self.navigationController?.isToolbarHidden = false
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
     

--- a/iOS/Airbnb/Airbnb/Search/View/SearchHeadCountViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SearchHeadCountViewController.swift
@@ -1,0 +1,29 @@
+//
+//  SearchHeadCountViewController.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/06/02.
+//
+
+import UIKit
+
+class SearchHeadCountViewController: BackgroundViewController, CommonViewControllerProtocol {
+    func attribute() {
+        view.backgroundColor = .systemBackground
+    }
+    
+    func layout() {
+        
+    }
+    
+    func bind() {
+        
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attribute()
+        layout()
+        bind()
+    }
+}

--- a/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
@@ -186,8 +186,10 @@ extension SearchViewController: UISearchBarDelegate {
                                          target: self, action: nil)
         backButton.tintColor = .gray
         self.navigationItem.backBarButtonItem = backButton
-        
-        navigationController?.pushViewController(LocationViewController(), animated: false)
+    
+        let locationViewController = LocationViewController()
+        locationViewController.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(locationViewController, animated: false)
     }
     
     private func setUpSearchController() {

--- a/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
@@ -14,6 +14,12 @@ class SearchViewController: BackgroundViewController, CommonViewControllerProtoc
         case searchMainBody
     }
     
+    private let searchBar: UISearchBar = {
+        let searchBar = UISearchBar()
+        searchBar.placeholder = "어디로 여행가세요?"
+        return searchBar
+    }()
+    
     private var searchMainCollectionViewLayout: UICollectionViewLayout {
         let inset = NSDirectionalEdgeInsets(
             top: 2, leading: 2, bottom: 2, trailing: 2)
@@ -143,12 +149,6 @@ class SearchViewController: BackgroundViewController, CommonViewControllerProtoc
         return collectionView
     }()
   
-    private let searchBar: UISearchBar = {
-        let searchBar = UISearchBar()
-        searchBar.placeholder = "어디로 여행가세요?"
-        return searchBar
-    }()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         layout()
@@ -181,11 +181,6 @@ extension SearchViewController: UISearchBarDelegate {
     
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         searchBar.resignFirstResponder()
-        let backButton = UIBarButtonItem(title: "뒤로", style: .plain,
-                                         target: self, action: nil)
-        backButton.tintColor = .gray
-        self.navigationItem.backBarButtonItem = backButton
-    
         let locationViewController = LocationViewController()
         locationViewController.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(locationViewController, animated: false)

--- a/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SearchViewController.swift
@@ -166,7 +166,6 @@ class SearchViewController: BackgroundViewController, CommonViewControllerProtoc
     
     func attribute() {
         setUpSearchController()
-        super.setUpNavigationAppearance()
     }
     
     func layout() {

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/HeaderReusableView.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/HeaderReusableView.swift
@@ -29,7 +29,7 @@ class HeaderReusableView: UICollectionReusableView {
         
         self.backgroundColor = .systemBackground
         text.snp.makeConstraints {
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().offset(16)
             $0.centerY.equalToSuperview()
         }
     }

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/HeaderReusableView.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/HeaderReusableView.swift
@@ -27,6 +27,7 @@ class HeaderReusableView: UICollectionReusableView {
         super.init(frame: frame)
         addSubview(text)
         
+        self.backgroundColor = .systemBackground
         text.snp.makeConstraints {
             $0.leading.equalToSuperview()
             $0.centerY.equalToSuperview()

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
@@ -18,8 +18,8 @@ class LocationCollectionViewCell: UICollectionViewCell {
         imageView.image = #imageLiteral(resourceName: "mockImage")
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
-        imageView.layer.cornerRadius = CGFloat(6)
-        imageView.frame = CGRect(x: 0, y: 0, width: 64, height: 64)
+        imageView.layer.cornerRadius = 6
+//        imageView.frame = CGRect(x: 0, y: 0, width: 64, height: 64)
         return imageView
     }()
     

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
@@ -43,6 +43,7 @@ class LocationCollectionViewCell: UICollectionViewCell {
     }
     
     private func attribute() {
+        self.backgroundColor = .systemBackground
         cityName.font = UIFont.systemFont(ofSize: 17, weight: .medium)
         cityName.textColor = #colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1)
         spendingTime.font = UIFont.systemFont(ofSize: 17, weight: .light)

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/LocationCollectionViewCell.swift
@@ -19,7 +19,6 @@ class LocationCollectionViewCell: UICollectionViewCell {
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = 6
-//        imageView.frame = CGRect(x: 0, y: 0, width: 64, height: 64)
         return imageView
     }()
     
@@ -66,5 +65,10 @@ class LocationCollectionViewCell: UICollectionViewCell {
             $0.leading.equalTo(cityImage.snp.trailing).offset(16)
             $0.centerY.equalToSuperview()
         }
+    }
+    
+    func updateInfomation(_ info: CityInformation) {
+        cityName.text = info.destination
+        spendingTime.text = (info as? PopularCityInfomation)?.distance
     }
 }

--- a/iOS/Airbnb/Airbnb/Search/View/SubView/SearchCellCommonType.swift
+++ b/iOS/Airbnb/Airbnb/Search/View/SubView/SearchCellCommonType.swift
@@ -12,6 +12,6 @@ protocol SearchCellCommonType: UICollectionViewCell {
     func setData(model: SearchViewModel)
 }
 
-extension UICollectionViewCell {
-    static var reuseIdentifier: String { String(describing: Self.self) }
-}
+//extension UICollectionViewCell {
+////    static var reuseIdentifier: String { String(describing: Self.self) }
+//}

--- a/iOS/Airbnb/Airbnb/Source/AppDelegate.swift
+++ b/iOS/Airbnb/Airbnb/Source/AppDelegate.swift
@@ -13,4 +13,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-

--- a/iOS/Airbnb/Airbnb/Source/CommonColors.swift
+++ b/iOS/Airbnb/Airbnb/Source/CommonColors.swift
@@ -1,0 +1,20 @@
+//
+//  CommonColors.swift
+//  Airbnb
+//
+//  Created by 백상휘 on 2022/05/31.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    static let gray1 = UIColor(named: "Grey1")
+    static let gray2 = UIColor(named: "Grey2")
+    static let gray3 = UIColor(named: "Grey3")
+    static let gray4 = UIColor(named: "Grey4")
+    static let gray5 = UIColor(named: "Grey5")
+    static let gray6 = UIColor(named: "Grey6")
+    static let primary = UIColor(named: "Primary")
+    static let secondary = UIColor(named: "Secondary")
+}

--- a/iOS/Airbnb/Airbnb/Source/CommonColors.swift
+++ b/iOS/Airbnb/Airbnb/Source/CommonColors.swift
@@ -9,12 +9,26 @@ import Foundation
 import UIKit
 
 extension UIColor {
-    static let gray1 = UIColor(named: "Grey1")
-    static let gray2 = UIColor(named: "Grey2")
-    static let gray3 = UIColor(named: "Grey3")
-    static let gray4 = UIColor(named: "Grey4")
-    static let gray5 = UIColor(named: "Grey5")
-    static let gray6 = UIColor(named: "Grey6")
-    static let primary = UIColor(named: "Primary")
-    static let secondary = UIColor(named: "Secondary")
+    
+    static func getGrayScale(_ scale: AirbnbGrayScale) -> UIColor? {
+        UIColor(named: scale.rawValue)
+    }
+    
+    static func getColorPalette(_ palette: AirbnbColorPalette) -> UIColor? {
+        UIColor(named: palette.rawValue)
+    }
+}
+
+enum AirbnbGrayScale: String {
+    case Grey1
+    case Grey2
+    case Grey3
+    case Grey4
+    case Grey5
+    case Grey6
+}
+
+enum AirbnbColorPalette: String {
+    case primary
+    case secondary
 }

--- a/iOS/Airbnb/AirbnbTests/AirbnbSearchUseCaseResponseTests.swift
+++ b/iOS/Airbnb/AirbnbTests/AirbnbSearchUseCaseResponseTests.swift
@@ -1,0 +1,17 @@
+//
+//  AirbnbSearchUseCaseResponseTests.swift
+//  AirbnbTests
+//
+//  Created by 백상휘 on 2022/05/30.
+//
+
+import XCTest
+@testable import Airbnb
+
+class AirbnbSearchUseCaseResponseTests: XCTestCase {
+    let useCase = SearchUseCase(urlString: <#T##String#>)
+    
+    func test_cities_response_test() throws {
+        
+    }
+}

--- a/iOS/Airbnb/AirbnbTests/AirbnbSearchUseCaseResponseTests.swift
+++ b/iOS/Airbnb/AirbnbTests/AirbnbSearchUseCaseResponseTests.swift
@@ -9,9 +9,29 @@ import XCTest
 @testable import Airbnb
 
 class AirbnbSearchUseCaseResponseTests: XCTestCase {
-    let useCase = SearchUseCase(urlString: <#T##String#>)
+    let useCase = SearchUseCase(urlString: "http://3.38.224.138:8080")
     
     func test_cities_response_test() throws {
-        
+        let expectation = XCTestExpectation()
+        useCase.getReservations { result in
+            
+            switch result {
+                
+            case .success(let data):
+                
+                guard let data = data else {
+                    XCTFail("No data")
+                    return
+                }
+                
+                if let reservation = try? JSONDecoder().decode(Reservations.self, from: data) {
+                    XCTAssertFalse(reservation.reservations.isEmpty)
+                }
+                
+            case .failure( _):
+                XCTFail("NetworkError")
+            }
+        }
+        wait(for: [expectation], timeout: 5.0)
     }
 }


### PR DESCRIPTION
# 2022/05/31 Pull Request

## 🔨 관련 Issue

- ak2j38/airbnb#22
- ak2j38/airbnb#24
- ak2j38/airbnb#25
- ak2j38/airbnb#61
- ak2j38/airbnb#63
- ak2j38/airbnb#66
- ak2j38/airbnb#67

## 👨🏻‍💻 작업 내용

1. API 연동하는 UseCase+UnitTest 를 작성해 보았습니다.
   - Quick&Dirty 로 연동이 가능한지만 알아보기 위해 코드 작성한 부분입니다.
   - Repository Layer 에서 적용해야 할 기능이기 때문에 BE 와의 소통을 위하여 기능 구현만 하였습니다.
   - 요구사항에 나온 Alamofire 를 이용하였습니다.
2. 가격 그래프를 UIBezierPath 를 이용하여 그렸습니다.
   - 동적인 그래프 폭을 적용하였습니다.
   - 동적인 그래프 컬럼 폭을 적용하였습니다.
3. 하단에 ToolBar 작업


## 📱 Simulation

![Graph_Simulation](https://user-images.githubusercontent.com/65931336/171114604-a9607ce0-52c7-4fc9-a92d-9c8d1a12083e.gif)

## 💭 고민한 점

1. 현재 Repository 구현을 위해 각 Repository(검색, 위시리스트, 내 정보)의 함수 정의를 Protocol에서 미리 해 놓은 뒤 클래스를 생성해서 구현하고 모델에 주입할 예정입니다.
Protocol을 정의하지 않고도 구현할 수 있지 않을까 생각하였지만, 미래에 있을 타입 확장성을 위해 Protocol을 지금 추가하는 것이 맞을까요?

2. 동일한 네비게이션 요소(네비바, 툴바)를 공유하는 뷰컨트롤러들이 조금씩 생기는데 어떻게 코드 중복을 막을 수 있을지 궁금합니다.
![중복 네비바, 툴바](https://user-images.githubusercontent.com/50472122/171116922-dc32a102-98db-4298-a924-716f44bacf1d.png)
왼쪽 부터 화면 두개가 하나의 뷰컨트롤러입니다. 6개의 화면이 총 3개의 뷰컨트롤러입니다.

3. Calender 를 View 에 그리는 로직

    레이웬더리치 튜토리얼을 보고 만드는 작업을 하고 있는데 로직 구현이 어렵네요.

## 🙏 To Reviewer

* PR일이 하루 앞당겨져서 작업량이 적습니다. 참고바랍니다. 