### PR TITLE
[Team-03] MVVM 패턴 적용

### DIFF
--- a/ios/AirBnb/AirBnb.xcodeproj/project.pbxproj
+++ b/ios/AirBnb/AirBnb.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		E4BE2A4C283E0500000099E5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BE2A4B283E0500000099E5 /* UIImage+Extensions.swift */; };
 		E4C5C1E32843141700FE8B21 /* Toolbox in Frameworks */ = {isa = PBXBuildFile; productRef = E4C5C1E22843141700FE8B21 /* Toolbox */; };
 		E4E3C2A7284855A200B5F7E1 /* ImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2A6284855A200B5F7E1 /* ImageFactory.swift */; };
+		E4E3C2A92848585000B5F7E1 /* DefaultImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2A82848585000B5F7E1 /* DefaultImageRepository.swift */; };
+		E4E3C2AC28485E5500B5F7E1 /* DefaultImageCacheStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2AB28485E5500B5F7E1 /* DefaultImageCacheStorage.swift */; };
+		E4E3C2B02848688E00B5F7E1 /* ImageCacheStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2AF2848688E00B5F7E1 /* ImageCacheStorage.swift */; };
 		E4F11DA6283F28330035CBC2 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DA5283F28330035CBC2 /* Observable.swift */; };
 		E4F11DAA283F5B710035CBC2 /* LocationSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DA9283F5B710035CBC2 /* LocationSearchController.swift */; };
 		E4F11DAD283F5F100035CBC2 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DAC283F5F100035CBC2 /* SearchResultViewController.swift */; };
@@ -65,6 +68,9 @@
 		E4BE2A48283DFD5F000099E5 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
 		E4BE2A4B283E0500000099E5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 		E4E3C2A6284855A200B5F7E1 /* ImageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFactory.swift; sourceTree = "<group>"; };
+		E4E3C2A82848585000B5F7E1 /* DefaultImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageRepository.swift; sourceTree = "<group>"; };
+		E4E3C2AB28485E5500B5F7E1 /* DefaultImageCacheStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageCacheStorage.swift; sourceTree = "<group>"; };
+		E4E3C2AF2848688E00B5F7E1 /* ImageCacheStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheStorage.swift; sourceTree = "<group>"; };
 		E4F11DA5283F28330035CBC2 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		E4F11DA9283F5B710035CBC2 /* LocationSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchController.swift; sourceTree = "<group>"; };
 		E4F11DAC283F5F100035CBC2 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
@@ -132,6 +138,8 @@
 			isa = PBXGroup;
 			children = (
 				E46F12942845A50B00BB168E /* Repositories */,
+				E4E3C2B1284868F500B5F7E1 /* Network */,
+				E4E3C2AA28485E1F00B5F7E1 /* PersistentStorage */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -149,6 +157,7 @@
 		E46F12942845A50B00BB168E /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				E4E3C2A82848585000B5F7E1 /* DefaultImageRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -269,6 +278,30 @@
 				E4E3C2A6284855A200B5F7E1 /* ImageFactory.swift */,
 			);
 			path = Interfaces;
+			sourceTree = "<group>";
+		};
+		E4E3C2AA28485E1F00B5F7E1 /* PersistentStorage */ = {
+			isa = PBXGroup;
+			children = (
+				E4E3C2AD2848686A00B5F7E1 /* ImageCacheStorage */,
+			);
+			path = PersistentStorage;
+			sourceTree = "<group>";
+		};
+		E4E3C2AD2848686A00B5F7E1 /* ImageCacheStorage */ = {
+			isa = PBXGroup;
+			children = (
+				E4E3C2AF2848688E00B5F7E1 /* ImageCacheStorage.swift */,
+				E4E3C2AB28485E5500B5F7E1 /* DefaultImageCacheStorage.swift */,
+			);
+			path = ImageCacheStorage;
+			sourceTree = "<group>";
+		};
+		E4E3C2B1284868F500B5F7E1 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		E4F11DAB283F5F030035CBC2 /* Search */ = {
@@ -406,12 +439,15 @@
 				E4F11DAA283F5B710035CBC2 /* LocationSearchController.swift in Sources */,
 				E471A09E284072F500232E5F /* HeroCollectionViewCell.swift in Sources */,
 				E4583FB7284226BA00A095BB /* UIView+Extensions.swift in Sources */,
+				E4E3C2AC28485E5500B5F7E1 /* DefaultImageCacheStorage.swift in Sources */,
 				E43DA4B0284769BC004619CD /* FetchImageUseCase.swift in Sources */,
 				E4E3C2A7284855A200B5F7E1 /* ImageFactory.swift in Sources */,
 				E471A09A2840673E00232E5F /* SectionFactory.swift in Sources */,
 				E4409DD8283B2A0E005C6BA1 /* HomeViewController.swift in Sources */,
 				E4BE2A47283DFD48000099E5 /* WishListViewController.swift in Sources */,
+				E4E3C2A92848585000B5F7E1 /* DefaultImageRepository.swift in Sources */,
 				E471A0A72840B04D00232E5F /* TitleSupplementaryView.swift in Sources */,
+				E4E3C2B02848688E00B5F7E1 /* ImageCacheStorage.swift in Sources */,
 				E4588F9D283E281E00544A6D /* UIColor+Extensions.swift in Sources */,
 				E46F129C2845E8FB00BB168E /* City.swift in Sources */,
 				E4BE2A4C283E0500000099E5 /* UIImage+Extensions.swift in Sources */,

--- a/ios/AirBnb/AirBnb.xcodeproj/project.pbxproj
+++ b/ios/AirBnb/AirBnb.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E4E3C2A92848585000B5F7E1 /* DefaultImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2A82848585000B5F7E1 /* DefaultImageRepository.swift */; };
 		E4E3C2AC28485E5500B5F7E1 /* DefaultImageCacheStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2AB28485E5500B5F7E1 /* DefaultImageCacheStorage.swift */; };
 		E4E3C2B02848688E00B5F7E1 /* ImageCacheStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2AF2848688E00B5F7E1 /* ImageCacheStorage.swift */; };
+		E4E3C2B42848AC6200B5F7E1 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2B32848AC6200B5F7E1 /* NetworkService.swift */; };
 		E4F11DA6283F28330035CBC2 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DA5283F28330035CBC2 /* Observable.swift */; };
 		E4F11DAA283F5B710035CBC2 /* LocationSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DA9283F5B710035CBC2 /* LocationSearchController.swift */; };
 		E4F11DAD283F5F100035CBC2 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DAC283F5F100035CBC2 /* SearchResultViewController.swift */; };
@@ -71,6 +72,7 @@
 		E4E3C2A82848585000B5F7E1 /* DefaultImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageRepository.swift; sourceTree = "<group>"; };
 		E4E3C2AB28485E5500B5F7E1 /* DefaultImageCacheStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageCacheStorage.swift; sourceTree = "<group>"; };
 		E4E3C2AF2848688E00B5F7E1 /* ImageCacheStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheStorage.swift; sourceTree = "<group>"; };
+		E4E3C2B32848AC6200B5F7E1 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		E4F11DA5283F28330035CBC2 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		E4F11DA9283F5B710035CBC2 /* LocationSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchController.swift; sourceTree = "<group>"; };
 		E4F11DAC283F5F100035CBC2 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				E46F12932845A4EC00BB168E /* Domain */,
 				E46F12922845A4E300BB168E /* Data */,
 				E45F2A81283B30C300F0CB7C /* Resources */,
+				E4E3C2B22848AC5600B5F7E1 /* Infrastructures */,
 			);
 			path = AirBnb;
 			sourceTree = "<group>";
@@ -304,6 +307,14 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		E4E3C2B22848AC5600B5F7E1 /* Infrastructures */ = {
+			isa = PBXGroup;
+			children = (
+				E4E3C2B32848AC6200B5F7E1 /* NetworkService.swift */,
+			);
+			path = Infrastructures;
+			sourceTree = "<group>";
+		};
 		E4F11DAB283F5F030035CBC2 /* Search */ = {
 			isa = PBXGroup;
 			children = (
@@ -442,6 +453,7 @@
 				E4E3C2AC28485E5500B5F7E1 /* DefaultImageCacheStorage.swift in Sources */,
 				E43DA4B0284769BC004619CD /* FetchImageUseCase.swift in Sources */,
 				E4E3C2A7284855A200B5F7E1 /* ImageFactory.swift in Sources */,
+				E4E3C2B42848AC6200B5F7E1 /* NetworkService.swift in Sources */,
 				E471A09A2840673E00232E5F /* SectionFactory.swift in Sources */,
 				E4409DD8283B2A0E005C6BA1 /* HomeViewController.swift in Sources */,
 				E4BE2A47283DFD48000099E5 /* WishListViewController.swift in Sources */,

--- a/ios/AirBnb/AirBnb.xcodeproj/project.pbxproj
+++ b/ios/AirBnb/AirBnb.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E43DA4B0284769BC004619CD /* FetchImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43DA4AF284769BC004619CD /* FetchImageUseCase.swift */; };
 		E4409DD4283B2A0E005C6BA1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4409DD3283B2A0E005C6BA1 /* AppDelegate.swift */; };
 		E4409DD6283B2A0E005C6BA1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4409DD5283B2A0E005C6BA1 /* SceneDelegate.swift */; };
 		E4409DD8283B2A0E005C6BA1 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4409DD7283B2A0E005C6BA1 /* HomeViewController.swift */; };
@@ -28,12 +29,14 @@
 		E4BE2A49283DFD5F000099E5 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BE2A48283DFD5F000099E5 /* ReservationViewController.swift */; };
 		E4BE2A4C283E0500000099E5 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BE2A4B283E0500000099E5 /* UIImage+Extensions.swift */; };
 		E4C5C1E32843141700FE8B21 /* Toolbox in Frameworks */ = {isa = PBXBuildFile; productRef = E4C5C1E22843141700FE8B21 /* Toolbox */; };
+		E4E3C2A7284855A200B5F7E1 /* ImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E3C2A6284855A200B5F7E1 /* ImageFactory.swift */; };
 		E4F11DA6283F28330035CBC2 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DA5283F28330035CBC2 /* Observable.swift */; };
 		E4F11DAA283F5B710035CBC2 /* LocationSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DA9283F5B710035CBC2 /* LocationSearchController.swift */; };
 		E4F11DAD283F5F100035CBC2 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F11DAC283F5F100035CBC2 /* SearchResultViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E43DA4AF284769BC004619CD /* FetchImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchImageUseCase.swift; sourceTree = "<group>"; };
 		E4409DD3283B2A0E005C6BA1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4409DD5283B2A0E005C6BA1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E4409DD7283B2A0E005C6BA1 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -61,6 +64,7 @@
 		E4BE2A46283DFD48000099E5 /* WishListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListViewController.swift; sourceTree = "<group>"; };
 		E4BE2A48283DFD5F000099E5 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
 		E4BE2A4B283E0500000099E5 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
+		E4E3C2A6284855A200B5F7E1 /* ImageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFactory.swift; sourceTree = "<group>"; };
 		E4F11DA5283F28330035CBC2 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		E4F11DA9283F5B710035CBC2 /* LocationSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchController.swift; sourceTree = "<group>"; };
 		E4F11DAC283F5F100035CBC2 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
@@ -137,6 +141,7 @@
 			children = (
 				E46F12962845A56E00BB168E /* Entities */,
 				E46F12992845AE4600BB168E /* UseCases */,
+				E4E3C2A5284854E000B5F7E1 /* Interfaces */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -160,6 +165,7 @@
 		E46F12992845AE4600BB168E /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				E43DA4AF284769BC004619CD /* FetchImageUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -255,6 +261,14 @@
 				E46F12A12845EED900BB168E /* Hashable+hash.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		E4E3C2A5284854E000B5F7E1 /* Interfaces */ = {
+			isa = PBXGroup;
+			children = (
+				E4E3C2A6284855A200B5F7E1 /* ImageFactory.swift */,
+			);
+			path = Interfaces;
 			sourceTree = "<group>";
 		};
 		E4F11DAB283F5F030035CBC2 /* Search */ = {
@@ -392,6 +406,8 @@
 				E4F11DAA283F5B710035CBC2 /* LocationSearchController.swift in Sources */,
 				E471A09E284072F500232E5F /* HeroCollectionViewCell.swift in Sources */,
 				E4583FB7284226BA00A095BB /* UIView+Extensions.swift in Sources */,
+				E43DA4B0284769BC004619CD /* FetchImageUseCase.swift in Sources */,
+				E4E3C2A7284855A200B5F7E1 /* ImageFactory.swift in Sources */,
 				E471A09A2840673E00232E5F /* SectionFactory.swift in Sources */,
 				E4409DD8283B2A0E005C6BA1 /* HomeViewController.swift in Sources */,
 				E4BE2A47283DFD48000099E5 /* WishListViewController.swift in Sources */,

--- a/ios/AirBnb/AirBnb/Data/PersistentStorage/ImageCacheStorage/DefaultImageCacheStorage.swift
+++ b/ios/AirBnb/AirBnb/Data/PersistentStorage/ImageCacheStorage/DefaultImageCacheStorage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class DefaultImageCacheStorage {
+final class DefaultImageCacheStorage {
   private let cache = NSCache<NSURL, NSData>()
 
   private var diskDirectoryURL: URL? {

--- a/ios/AirBnb/AirBnb/Data/PersistentStorage/ImageCacheStorage/DefaultImageCacheStorage.swift
+++ b/ios/AirBnb/AirBnb/Data/PersistentStorage/ImageCacheStorage/DefaultImageCacheStorage.swift
@@ -1,0 +1,63 @@
+//
+//  ImageCache.swift
+//  AirBnb
+//
+//  Created by 송태환 on 2022/06/02.
+//
+
+import Foundation
+
+class DefaultImageCacheStorage {
+  private let cache = NSCache<NSURL, NSData>()
+
+  private var diskDirectoryURL: URL? {
+    try? FileManager.default.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
+  }
+
+  private func joinPath(base: String, path: [String]) -> String {
+    path.reduce(base) { "\($0)/\($1)" }
+  }
+
+  private func getDiskFileURL(forKey url: NSURL) -> URL? {
+    guard let directoryURL = diskDirectoryURL, let filename = url.lastPathComponent else {
+      return nil
+    }
+
+    let path = joinPath(base: directoryURL.path, path: [filename])
+
+    return URL(fileURLWithPath: path)
+  }
+
+  private func getValueFromDiskCache(forKey url: NSURL) -> Data? {
+    guard let fileURL = getDiskFileURL(forKey: url) else {
+      return nil
+    }
+
+    guard let data = try? Data(contentsOf: fileURL) else {
+      return nil
+    }
+
+    store(data, forKey: url)
+
+    return data
+  }
+}
+
+extension DefaultImageCacheStorage: ImageCacheStorage {
+  func retrieve(forKey url: NSURL) -> Data? {
+    if let value = cache.object(forKey: url) as? Data {
+      return value
+    }
+
+    return getValueFromDiskCache(forKey: url)
+  }
+
+  func store(_ value: Data, forKey url: NSURL) {
+    cache.setObject(value as NSData, forKey: url)
+  }
+}

--- a/ios/AirBnb/AirBnb/Data/PersistentStorage/ImageCacheStorage/ImageCacheStorage.swift
+++ b/ios/AirBnb/AirBnb/Data/PersistentStorage/ImageCacheStorage/ImageCacheStorage.swift
@@ -1,0 +1,13 @@
+//
+//  ImageCacheStorage.swift
+//  AirBnb
+//
+//  Created by 송태환 on 2022/06/02.
+//
+
+import Foundation
+
+protocol ImageCacheStorage {
+  func retrieve(forKey url: NSURL) -> Data?
+  func store(_ value: Data, forKey url: NSURL)
+}

--- a/ios/AirBnb/AirBnb/Data/Repositories/DefaultImageRepository.swift
+++ b/ios/AirBnb/AirBnb/Data/Repositories/DefaultImageRepository.swift
@@ -1,0 +1,32 @@
+//
+//  DefaultImageRepository.swift
+//  AirBnb
+//
+//  Created by 송태환 on 2022/06/02.
+//
+
+import Foundation
+
+protocol DataTransferService {
+  func request(with url: URL)
+}
+
+class DefaultImageRepository: ImageRepository {
+  private let dataTransferService: DataTransferService
+  private let cache: ImageCacheStorage
+
+  init(dataTransferService: DataTransferService, cache: ImageCacheStorage) {
+    self.dataTransferService = dataTransferService
+    self.cache = cache
+  }
+
+  func fetchImage(with url: String, completion: @escaping (Result<Data, Error>) -> Void) {
+    guard let key = NSURL(string: url) else {
+      return
+    }
+
+    if let image = cache.retrieve(forKey: key) {
+      return completion(.success(image))
+    }
+  }
+}

--- a/ios/AirBnb/AirBnb/Data/Repositories/DefaultImageRepository.swift
+++ b/ios/AirBnb/AirBnb/Data/Repositories/DefaultImageRepository.swift
@@ -11,7 +11,7 @@ protocol DataTransferService {
   func request(with url: URL)
 }
 
-class DefaultImageRepository: ImageRepository {
+final class DefaultImageRepository: ImageRepository {
   private let dataTransferService: DataTransferService
   private let cache: ImageCacheStorage
 

--- a/ios/AirBnb/AirBnb/Domain/Entities/City.swift
+++ b/ios/AirBnb/AirBnb/Domain/Entities/City.swift
@@ -14,11 +14,4 @@ struct City: Hashable, Identifiable {
   let name: String
   let distance: String
   let imageUrl: String
-
-  init(id: Identifier, name: String, distance: String, imageUrl: String) {
-    self.id = id
-    self.name = name
-    self.distance = distance
-    self.imageUrl = imageUrl
-  }
 }

--- a/ios/AirBnb/AirBnb/Domain/Interfaces/ImageFactory.swift
+++ b/ios/AirBnb/AirBnb/Domain/Interfaces/ImageFactory.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+protocol ImageRepository {
+	func fetchImage(with url: String, completion: @escaping (Result<Data, Error>) -> Void)
+}

--- a/ios/AirBnb/AirBnb/Domain/Interfaces/ImageFactory.swift
+++ b/ios/AirBnb/AirBnb/Domain/Interfaces/ImageFactory.swift
@@ -1,0 +1,8 @@
+//
+//  ImageFactory.swift
+//  AirBnb
+//
+//  Created by 송태환 on 2022/06/02.
+//
+
+import Foundation

--- a/ios/AirBnb/AirBnb/Domain/Interfaces/ImageFactory.swift
+++ b/ios/AirBnb/AirBnb/Domain/Interfaces/ImageFactory.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol ImageRepository {
-	func fetchImage(with url: String, completion: @escaping (Result<Data, Error>) -> Void)
+  func fetchImage(with url: String, completion: @escaping (Result<Data, Error>) -> Void)
 }

--- a/ios/AirBnb/AirBnb/Domain/UseCases/FetchImageUseCase.swift
+++ b/ios/AirBnb/AirBnb/Domain/UseCases/FetchImageUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  FetchImageUseCase.swift
+//  AirBnb
+//
+//  Created by 송태환 on 2022/06/01.
+//
+
+import Foundation
+
+final class FetchImageUseCase {
+  struct RequestValue {
+    let url: String
+  }
+
+  typealias ResultValue = Result<Data, Error>
+
+  private let completion: (ResultValue) -> Void
+  private let imageRepository: ImageRepository
+  private let request: RequestValue
+
+  init(request: RequestValue, completion: @escaping (ResultValue) -> Void, imageRepository: ImageRepository) {
+    self.request = request
+    self.completion = completion
+    self.imageRepository = imageRepository
+  }
+
+  // UseCase 는 조금 더 Business specific 하기 때문에 매개변수 값에 따라 다른 데이터를 가져올 수 있도록 가능성을 열어두는 것보다는
+  // 생성자를 통해서만 필요한 값을 받아 한 도메인 종류(배너)의 데이터(지금의 경우는 Data 이지만 필요에 따라 [Accommodation] 등등)만 가져오게끔 하는 것이 특정 시나리오를 대변하는 느낌이지 않나...
+  // UseCase 클래스 자체는 재사용 가능하지만
+  func start() {
+    imageRepository.fetchImage(with: request.url, completion: completion)
+  }
+}
+
+protocol ImageRepository {
+  func fetchImage(with url: String, completion: @escaping (Result<Data, Error>) -> Void)
+}

--- a/ios/AirBnb/AirBnb/Domain/UseCases/FetchImageUseCase.swift
+++ b/ios/AirBnb/AirBnb/Domain/UseCases/FetchImageUseCase.swift
@@ -14,24 +14,18 @@ final class FetchImageUseCase {
 
   typealias ResultValue = Result<Data, Error>
 
-  private let completion: (ResultValue) -> Void
   private let imageRepository: ImageRepository
   private let request: RequestValue
 
-  init(request: RequestValue, completion: @escaping (ResultValue) -> Void, imageRepository: ImageRepository) {
+  init(request: RequestValue, imageRepository: ImageRepository) {
     self.request = request
-    self.completion = completion
     self.imageRepository = imageRepository
   }
 
   // UseCase 는 조금 더 Business specific 하기 때문에 매개변수 값에 따라 다른 데이터를 가져올 수 있도록 가능성을 열어두는 것보다는
   // 생성자를 통해서만 필요한 값을 받아 한 도메인 종류(배너)의 데이터(지금의 경우는 Data 이지만 필요에 따라 [Accommodation] 등등)만 가져오게끔 하는 것이 특정 시나리오를 대변하는 느낌이지 않나...
-  // UseCase 클래스 자체는 재사용 가능하지만
-  func start() {
+  // UseCase 클래스 자체는 재사용 가능하지만 인스턴스 생성 시 request 의 변경 가능성을 닫고 항상 같은 아웃풋을 얻도록 제한
+  func start(completion: @escaping (ResultValue) -> Void) {
     imageRepository.fetchImage(with: request.url, completion: completion)
   }
-}
-
-protocol ImageRepository {
-  func fetchImage(with url: String, completion: @escaping (Result<Data, Error>) -> Void)
 }

--- a/ios/AirBnb/AirBnb/Infrastructures/NetworkService.swift
+++ b/ios/AirBnb/AirBnb/Infrastructures/NetworkService.swift
@@ -1,0 +1,50 @@
+//
+//  NetworkService.swift
+//  AirBnb
+//
+//  Created by 송태환 on 2022/06/02.
+//
+
+import Foundation
+import OSLog
+
+enum NetworkError: Error {
+  case parseError
+  case error(statusCode: Int, data: Data?)
+  case emptyData
+}
+
+final class NetworkService {
+  private let session: URLSession
+
+  init(session: URLSession = URLSession.shared) {
+    self.session = session
+  }
+
+  func request<T: Decodable>(request: URLRequest, completion: @escaping (Result<T, NetworkError>) -> Void) {
+    session.dataTask(with: request) { data, response, error in
+      if let error = error {
+        if let response = response as? HTTPURLResponse {
+          completion(.failure(.error(statusCode: response.statusCode, data: data)))
+        } else {
+          // TODO: Request Error handling
+          Logger().error("\(error.localizedDescription)")
+        }
+
+        return
+      }
+
+      guard let data = data else {
+        completion(.failure(.emptyData))
+        return
+      }
+
+      do {
+        let result = try JSONDecoder().decode(T.self, from: data)
+        completion(.success(result))
+      } catch {
+        completion(.failure(.parseError))
+      }
+    }
+  }
+}

--- a/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/HeroCollectionViewCell.swift
+++ b/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/HeroCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import SnapKit
 import UIKit
 
-class HeroCollectionViewCell: UICollectionViewCell {
+final class HeroCollectionViewCell: UICollectionViewCell {
   private let backgroundImageView = UIImageView(frame: .zero)
   private let title = UILabel()
   private let subtitle = UILabel()

--- a/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/NearCityCollectionViewCell.swift
+++ b/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/NearCityCollectionViewCell.swift
@@ -53,9 +53,6 @@ class NearCityCollectionViewCell: UICollectionViewCell {
     contentView.addSubview(thumbnailView)
     thumbnailView.snp.makeConstraints { make in
       make.size.equalTo(contentView.snp.height)
-      make.top.equalTo(contentView)
-      make.leading.equalTo(contentView)
-      make.bottom.equalTo(contentView)
     }
 
     let stack = UIStackView(arrangedSubviews: [title, subtitle])

--- a/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/NearCityCollectionViewCell.swift
+++ b/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/NearCityCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import SnapKit
 import UIKit
 
-class NearCityCollectionViewCell: UICollectionViewCell {
+final class NearCityCollectionViewCell: UICollectionViewCell {
   private let thumbnailView = UIImageView(frame: .zero)
   private let title = UILabel()
   private let subtitle = UILabel()

--- a/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/RecommendationCollectionViewCell.swift
+++ b/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/RecommendationCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import SnapKit
 import UIKit
 
-class RecommendationCollectionViewCell: UICollectionViewCell {
+final class RecommendationCollectionViewCell: UICollectionViewCell {
   private let imageView = UIImageView(frame: .zero)
   private let title = UILabel(frame: .zero)
 

--- a/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/TitleSupplementaryView.swift
+++ b/ios/AirBnb/AirBnb/Presentation/Scenes/Home/View/TitleSupplementaryView.swift
@@ -8,7 +8,7 @@
 import SnapKit
 import UIKit
 
-class TitleSupplementaryView: UICollectionReusableView {
+final class TitleSupplementaryView: UICollectionReusableView {
   static let reuseIdentifier = "TitleSupplementaryView"
 
   let label = UILabel()


### PR DESCRIPTION
### 작업내용
- 메인 화면 MVVM 패턴 적용
- UseCase, Repository 구현
- 이미지 캐싱 Storage 객체 구현

### 메인 화면 MVVM 다이어그램
![arch](https://user-images.githubusercontent.com/42037023/171802278-8a7e01c8-60d0-4d01-b644-1a67750e92d7.png)

### 다음주 계획
- 범용성 및 테스트 가능한 API Client 객체 구현
- 메인 화면 도메인에 맞는 Service 객체 구현
- 의존성 주입을 담당하는 DIContainer 구현
- UISearchViewController 와 UICollectionView 를 활용하여 주소 검색 화면 구현

### 고민
고민 - Testable 한 네트워크 객체를 만들어 보고 있습니다.
문제 - URLSessionDataTask 를 상속 받아 URLSession 을 테스트하는 방식이 iOS 13 부터 deprecated 되었다고 합니다.
계획 - URLProtocol 과 URLSessionConfiguration 을 사용하는 방식을 적용해 테스트 가능하고 범용성 있는 NetworkService 객체를 만들어볼 계획입니다.

### 질문
질문.1 - 시나리오라고 할만큼 복잡한 네트워크 작업은 없지만 학습 목적으로 UseCase 를 만들어 보았습니다. 데이터를 가져와 단순히 화면에 표시하는 것이 전부인 화면의 경우 UseCase 를 사용하지 않는 것이 더 적절할까요?

질문.2 - 데이터의 성격 별로 UseCase 를 나누었습니다. ViewModel 여러 UseCase 를 가지는 것이 복잡도를 높이는 일인 것 같다는 생각이 들었습니다. 홈 화면의 데이터 흐름을 하나의 시나리오로 바라보고 하나의 UseCase 로 묶는 것이 좋을까요?
