### PR TITLE
[iOS] 검색화면 하단 탭 & FilterViewModel 구현 

### DIFF
--- a/Airbnb/Airbnb/Helpers/FlowLayoutMaker.swift
+++ b/Airbnb/Airbnb/Helpers/FlowLayoutMaker.swift
@@ -15,7 +15,7 @@ enum HomeSection: Int {
 
 enum FilterSection: Int {
     case container
-    case filterForm
+    case filterList
 }
 
 protocol LayoutProvidable {
@@ -90,13 +90,13 @@ struct HomeLayout: LayoutProvidable {
             let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                                           heightDimension: .fractionalHeight(1.0))
             let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                   heightDimension: .fractionalHeight(0.65))
+                                                   heightDimension: .fractionalHeight(0.73))
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
             let section = NSCollectionLayoutSection(group: group)
             return section
 
-        case .filterForm:
+        case .filterList:
             let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
             let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: env)
             return section

--- a/Airbnb/Airbnb/Helpers/FlowLayoutMaker.swift
+++ b/Airbnb/Airbnb/Helpers/FlowLayoutMaker.swift
@@ -22,7 +22,7 @@ protocol LayoutProvidable {
     func createSection(at: Int) -> NSCollectionLayoutSection?
 }
 
-struct FlowLayout {
+enum FlowLayout {
 
     static func makeCompositionalLayout (_ provider: LayoutProvidable) -> UICollectionViewCompositionalLayout {
         let layout = UICollectionViewCompositionalLayout { (sectionIndex: Int, _: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
@@ -35,8 +35,8 @@ struct FlowLayout {
 
 struct HomeLayout: LayoutProvidable {
 
-    func createSection(at: Int) -> NSCollectionLayoutSection? {
-        let section = HomeSection.init(rawValue: at)
+    func createSection(at section: Int) -> NSCollectionLayoutSection? {
+        let section = HomeSection.init(rawValue: section)
 
         switch section {
         case .banner:
@@ -82,8 +82,8 @@ struct HomeLayout: LayoutProvidable {
 }
 
  struct FilterLayout: LayoutProvidable {
-    func createSection(at: Int) -> NSCollectionLayoutSection? {
-        let section = FilterSection.init(rawValue: at)
+    func createSection(at section: Int) -> NSCollectionLayoutSection? {
+        let section = FilterSection.init(rawValue: section)
         switch section {
 
         case .container:

--- a/Airbnb/Airbnb/Helpers/FlowLayoutMaker.swift
+++ b/Airbnb/Airbnb/Helpers/FlowLayoutMaker.swift
@@ -19,14 +19,14 @@ enum FilterSection: Int {
 }
 
 protocol LayoutProvidable {
-    func createSection(at: Int) -> NSCollectionLayoutSection?
+    func createSection(at section: Int, env: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection?
 }
 
 enum FlowLayout {
 
     static func makeCompositionalLayout (_ provider: LayoutProvidable) -> UICollectionViewCompositionalLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex: Int, _: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
-            guard let section = provider.createSection(at: sectionIndex) else {return nil}
+        let layout = UICollectionViewCompositionalLayout { (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+            guard let section = provider.createSection(at: sectionIndex, env: layoutEnvironment) else {return nil}
             return section
         }
         return layout
@@ -35,7 +35,7 @@ enum FlowLayout {
 
 struct HomeLayout: LayoutProvidable {
 
-    func createSection(at section: Int) -> NSCollectionLayoutSection? {
+    func createSection(at section: Int, env: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? {
         let section = HomeSection.init(rawValue: section)
 
         switch section {
@@ -82,7 +82,7 @@ struct HomeLayout: LayoutProvidable {
 }
 
  struct FilterLayout: LayoutProvidable {
-    func createSection(at section: Int) -> NSCollectionLayoutSection? {
+     func createSection(at section: Int, env: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? {
         let section = FilterSection.init(rawValue: section)
         switch section {
 
@@ -90,20 +90,15 @@ struct HomeLayout: LayoutProvidable {
             let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                                           heightDimension: .fractionalHeight(1.0))
             let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                   heightDimension: .fractionalHeight(0.6))
+                                                   heightDimension: .fractionalHeight(0.65))
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
             let section = NSCollectionLayoutSection(group: group)
             return section
 
         case .filterForm:
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                  heightDimension: .fractionalHeight(1.0))
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                   heightDimension: .fractionalHeight(0.07))
-            let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-            let section = NSCollectionLayoutSection(group: group)
+            let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+            let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: env)
             return section
 
         case .none:

--- a/Airbnb/Airbnb/Screens/Filter/Model/FilterCategory.swift
+++ b/Airbnb/Airbnb/Screens/Filter/Model/FilterCategory.swift
@@ -36,9 +36,6 @@ struct FilterList {
     let occupants: Occupants
 }
 
-enum FilterFields: String, CaseIterable {
-    case location = "위치"
-    case period = "체크인/체크아웃"
-    case priceRange = "요금"
-    case occupants = "인원"
+enum FilterFields {
+    static let fields = ["위치", "체크인/체크아웃", "요금", "인원"]
 }

--- a/Airbnb/Airbnb/Screens/Filter/Model/FilterCategory.swift
+++ b/Airbnb/Airbnb/Screens/Filter/Model/FilterCategory.swift
@@ -27,15 +27,36 @@ struct Occupants {
     let adult: Int
     let children: Int
     let infant: Int
+    var numberOfGuest: Int {
+        return adult + children + infant
+    }
 }
 
-struct FilterList {
-    let location: Location
-    let persiod: Period
-    let priceRange: PriceRange
-    let occupants: Occupants
-}
+struct FilterSelection {
+    let location: Location?
+    let period: Period?
+    let priceRange: PriceRange?
+    let occupants: Occupants?
+ }
 
-enum FilterFields {
-    static let fields = ["위치", "체크인/체크아웃", "요금", "인원"]
+enum FilterFields: Int, CaseIterable {
+    case location
+    case period
+    case price
+    case occupants
+
+    var description: String {
+        switch self {
+        case .location:
+            return "위치"
+        case .period:
+            return "체크인/체크아웃"
+        case .price:
+            return "요금"
+        case .occupants:
+            return "인원"
+
+        }
+    }
+
 }

--- a/Airbnb/Airbnb/Screens/Filter/View/FilterListCell.swift
+++ b/Airbnb/Airbnb/Screens/Filter/View/FilterListCell.swift
@@ -11,14 +11,14 @@ final class FilterListCell: UICollectionViewListCell {
 
     static let id = "FilterFormCell"
 
-    var field: UILabel = {
+    private var field: UILabel = {
         let label = UILabel()
         label.font = .mediumRegular
         label.textAlignment = .left
         return label
     }()
 
-    var fieldValue: UILabel = {
+    private var fieldValue: UILabel = {
         let label = UILabel()
         label.font = .mediumRegular
         label.textColor = .secondarySystemBackground
@@ -26,7 +26,7 @@ final class FilterListCell: UICollectionViewListCell {
         return label
     }()
 
-    lazy var stackView: UIStackView = {
+    private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [field, fieldValue])
         stackView.distribution = .fillProportionally
         stackView.axis = .horizontal

--- a/Airbnb/Airbnb/Screens/Filter/View/FilterListCell.swift
+++ b/Airbnb/Airbnb/Screens/Filter/View/FilterListCell.swift
@@ -49,8 +49,17 @@ final class FilterListCell: UICollectionViewListCell {
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            stackView.heightAnchor.constraint(equalToConstant: 44)
         ])
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        automaticallyUpdatesBackgroundConfiguration = false
+    }
+
+    func configure (title: String, value: String) {
+        field.text = title
+        fieldValue.text = value
     }
 
     required init?(coder: NSCoder) {

--- a/Airbnb/Airbnb/Screens/Filter/View/FilterListCell.swift
+++ b/Airbnb/Airbnb/Screens/Filter/View/FilterListCell.swift
@@ -13,15 +13,15 @@ final class FilterListCell: UICollectionViewListCell {
 
     private var field: UILabel = {
         let label = UILabel()
-        label.font = .mediumRegular
+        label.font = .smallRegular
         label.textAlignment = .left
         return label
     }()
 
     private var fieldValue: UILabel = {
         let label = UILabel()
-        label.font = .mediumRegular
-        label.textColor = .secondarySystemBackground
+        label.font = .smallRegular
+        label.textColor = .gray3
         label.textAlignment = .right
         return label
     }()
@@ -57,9 +57,10 @@ final class FilterListCell: UICollectionViewListCell {
         automaticallyUpdatesBackgroundConfiguration = false
     }
 
-    func configure (title: String, value: String) {
-        field.text = title
-        fieldValue.text = value
+    func configure(_ model: FilterListCellViewModel?) {
+        guard let model = model else {return}
+        field.text = model.fieldTitle
+        fieldValue.text = model.fieldValue
     }
 
     required init?(coder: NSCoder) {

--- a/Airbnb/Airbnb/Screens/Filter/View/FilterViewController.swift
+++ b/Airbnb/Airbnb/Screens/Filter/View/FilterViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class FilterViewController: UIViewController {
 
-    var filterForm: UICollectionView!
+    private var filterForm: UICollectionView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,11 +34,11 @@ final class FilterViewController: UIViewController {
         filterForm.dataSource = self
         filterForm.register(FilterListCell.self, forCellWithReuseIdentifier: FilterListCell.id)
         filterForm.register(ContainerCell.self, forCellWithReuseIdentifier: ContainerCell.id)
-        view.addSubview(filterForm)
         filterForm.translatesAutoresizingMaskIntoConstraints = false
     }
 
     private func configureConstraints() {
+        view.addSubview(filterForm)
         NSLayoutConstraint.activate([
             filterForm.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             filterForm.trailingAnchor.constraint(equalTo: view.trailingAnchor),

--- a/Airbnb/Airbnb/Screens/Filter/View/FilterViewController.swift
+++ b/Airbnb/Airbnb/Screens/Filter/View/FilterViewController.swift
@@ -31,6 +31,7 @@ final class FilterViewController: UIViewController {
         let layoutProvider = FilterLayout()
         let layout = FlowLayout.makeCompositionalLayout(layoutProvider)
         filterForm = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        filterForm.isScrollEnabled = false
         filterForm.dataSource = self
         filterForm.register(FilterListCell.self, forCellWithReuseIdentifier: FilterListCell.id)
         filterForm.register(ContainerCell.self, forCellWithReuseIdentifier: ContainerCell.id)
@@ -77,7 +78,7 @@ extension FilterViewController: UICollectionViewDataSource {
 
         case .filterForm:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FilterListCell.id, for: indexPath) as? FilterListCell else {return UICollectionViewListCell()}
-            cell.contentView.backgroundColor = .blue
+            cell.configure(title: "test", value: "dd")
             return cell
         }
 

--- a/Airbnb/Airbnb/Screens/Filter/View/FilterViewController.swift
+++ b/Airbnb/Airbnb/Screens/Filter/View/FilterViewController.swift
@@ -10,16 +10,28 @@ import UIKit
 final class FilterViewController: UIViewController {
 
     private var filterForm: UICollectionView!
+    private var filterViewModel: FilterViewModel?
+
+    init(filterViewModel: FilterViewModel) {
+        self.filterViewModel = filterViewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureDisplay()
         configureConstraints()
+
     }
 
     private func configureDisplay() {
         setViewController()
         setFilterForm()
+        setDataBinding()
     }
 
     private func setViewController() {
@@ -48,6 +60,33 @@ final class FilterViewController: UIViewController {
         ])
     }
 
+    private func setDataBinding() {
+        filterViewModel?.location.bind(listener: { [weak self] model in
+            guard let model = model else { return }
+            let viewModel = FilterListCellViewModel(model: model)
+            self?.filterViewModel?.update(type: .location, viewModel: viewModel)
+            self?.filterForm.reloadData()
+        })
+        filterViewModel?.period.bind(listener: { [weak self] model in
+            guard let model = model else { return }
+            let viewModel = FilterListCellViewModel(model: model)
+            self?.filterViewModel?.update(type: .period, viewModel: viewModel)
+            self?.filterForm.reloadData()
+        })
+        filterViewModel?.price.bind(listener: { [weak self] model in
+            guard let model = model else { return }
+            let viewModel = FilterListCellViewModel(model: model)
+            self?.filterViewModel?.update(type: .price, viewModel: viewModel)
+            self?.filterForm.reloadData()
+        })
+        filterViewModel?.occupants.bind(listener: { [weak self] model in
+            guard let model = model else { return }
+            let viewModel = FilterListCellViewModel(model: model)
+            self?.filterViewModel?.update(type: .occupants, viewModel: viewModel)
+            self?.filterForm.reloadData()
+        })
+    }
+
 }
 
 extension FilterViewController: UICollectionViewDataSource {
@@ -63,7 +102,7 @@ extension FilterViewController: UICollectionViewDataSource {
             return 1
 
         case .filterForm:
-            return 4
+            return filterViewModel?.listCellViewModel.count ?? 0
         }
     }
 
@@ -78,7 +117,7 @@ extension FilterViewController: UICollectionViewDataSource {
 
         case .filterForm:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FilterListCell.id, for: indexPath) as? FilterListCell else {return UICollectionViewListCell()}
-            cell.configure(title: "test", value: "dd")
+            cell.configure(filterViewModel?[indexPath])
             return cell
         }
 

--- a/Airbnb/Airbnb/Screens/Filter/ViewModel/FilterListCellViewModel.swift
+++ b/Airbnb/Airbnb/Screens/Filter/ViewModel/FilterListCellViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  FilterListCellViewModel.swift
+//  Airbnb
+//
+//  Created by Kai Kim on 2022/06/01.
+//
+
+import Foundation
+
+struct FilterListCellViewModel {
+    let fieldTitle: String
+    let fieldValue: String?
+
+    init(model: Location) {
+        fieldTitle = FilterFields.location.description
+        fieldValue = model.name
+    }
+
+    init(model: Period) {
+        fieldTitle = FilterFields.period.description
+        fieldValue = "\(model.start) - \(model.end)"
+    }
+
+    init(model: PriceRange) {
+        fieldTitle = FilterFields.price.description
+        fieldValue = "\(model.min) - \(model.max)"
+    }
+
+    init(model: Occupants) {
+        fieldTitle = FilterFields.occupants.description
+        fieldValue = "게스트 \(model.numberOfGuest)명"
+    }
+
+    init(fieldTitle: String, fieldValue: String? = nil) {
+        self.fieldTitle = fieldTitle
+        self.fieldValue = fieldValue
+    }
+}

--- a/Airbnb/Airbnb/Screens/Filter/ViewModel/FilterListViewModel.swift
+++ b/Airbnb/Airbnb/Screens/Filter/ViewModel/FilterListViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  FilterListViewModel.swift
+//  Airbnb
+//
+//  Created by Kai Kim on 2022/06/01.
+//
+
+import Foundation
+
+final class FilterViewModel {
+
+    var location = Observable<Location?>(nil)
+    var period =  Observable<Period?>(nil)
+    var price =  Observable<PriceRange?>(nil)
+    var occupants = Observable<Occupants?>(nil)
+
+    var listCellViewModel: [FilterFields: FilterListCellViewModel] = [:]
+
+    init() {
+        for field in FilterFields.allCases {
+            listCellViewModel.updateValue(FilterListCellViewModel(fieldTitle: field.description), forKey: field)
+        }
+    }
+
+    subscript(_ index: IndexPath) -> FilterListCellViewModel? {
+        guard let field = FilterFields.init(rawValue: index.item), let viewModel = listCellViewModel[field] else {return nil}
+        return viewModel
+    }
+
+    func update(type: FilterFields, viewModel: FilterListCellViewModel) {
+        listCellViewModel.updateValue(viewModel, forKey: type)
+    }
+
+}

--- a/Airbnb/Airbnb/Screens/Home/View/HomeViewController.swift
+++ b/Airbnb/Airbnb/Screens/Home/View/HomeViewController.swift
@@ -58,10 +58,10 @@ final class HomeViewController: UIViewController, UISearchBarDelegate {
         homeCollectionView.register(RandomSiteCell.self, forCellWithReuseIdentifier: RandomSiteCell.id)
         homeCollectionView.register(SectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: SectionHeader.id)
         homeCollectionView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(homeCollectionView)
     }
 
     private func configureConstraints() {
+        view.addSubview(homeCollectionView)
         NSLayoutConstraint.activate([
             homeCollectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: 50),
             homeCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),

--- a/Airbnb/Airbnb/Screens/Search/View/SearchViewController.swift
+++ b/Airbnb/Airbnb/Screens/Search/View/SearchViewController.swift
@@ -24,11 +24,6 @@ final class SearchViewController: UIViewController, UISearchResultsUpdating {
         configureSearchCompleter()
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        searchCompleter = nil
-    }
-
     private func configureDisplay() {
         setViewController()
         setSearchController()
@@ -96,6 +91,7 @@ final class SearchViewController: UIViewController, UISearchResultsUpdating {
         guard let text = searchController.searchBar.text else {return}
         if text.isEmpty {
             citySearchViewModel.reset()
+            completerResults = nil
             return
         }
         searchCompleter?.queryFragment = text
@@ -145,9 +141,11 @@ extension SearchViewController: UICollectionViewDelegate {
             guard error == nil else {return}
             guard let placeMark = response?.mapItems[0].placemark, let title = placeMark.title else {return}
 
-            // TODO: Location 정보를 nextVC 에 넘겨주어야함.
             let location = Location(name: title, latitude: placeMark.coordinate.latitude, longitude: placeMark.coordinate.longitude)
-            let nextVC = FilterViewController()
+            let filterViewModel = FilterViewModel()
+            filterViewModel.location.value = location
+            let nextVC = FilterViewController(filterViewModel: filterViewModel)
+
             self?.navigationController?.pushViewController(nextVC, animated: true)
         }
 

--- a/Airbnb/Airbnb/Screens/Search/View/SearchViewController.swift
+++ b/Airbnb/Airbnb/Screens/Search/View/SearchViewController.swift
@@ -45,15 +45,15 @@ final class SearchViewController: UIViewController, UISearchResultsUpdating {
     private func configureViewModel() {
         citySearchViewModel.reset()
 
-        citySearchViewModel.headerVM.bind { _ in
+        citySearchViewModel.headerVM.bind {[weak self] _ in
             DispatchQueue.main.async {
-                self.collectionView.reloadData()
+                self?.collectionView.reloadData()
             }
         }
 
-        citySearchViewModel.cityVM.bind { _ in
+        citySearchViewModel.cityVM.bind {[weak self] _ in
             DispatchQueue.main.async {
-                self.collectionView.reloadData()
+                self?.collectionView.reloadData()
             }
         }
     }
@@ -80,10 +80,10 @@ final class SearchViewController: UIViewController, UISearchResultsUpdating {
         collectionView.delegate = self
         collectionView.register(CityCell.self, forCellWithReuseIdentifier: CityCell.id)
         collectionView.register(SectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: SectionHeader.id)
-        view.addSubview(collectionView)
     }
 
     private func configureConstraints() {
+        view.addSubview(collectionView)
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -141,14 +141,14 @@ extension SearchViewController: UICollectionViewDelegate {
         let searchRequest = MKLocalSearch.Request(completion: selectedRegion)
         let search = MKLocalSearch(request: searchRequest)
 
-        search.start { (response, error) in
+        search.start { [weak self] (response, error) in
             guard error == nil else {return}
             guard let placeMark = response?.mapItems[0].placemark, let title = placeMark.title else {return}
 
             // TODO: Location 정보를 nextVC 에 넘겨주어야함.
             let location = Location(name: title, latitude: placeMark.coordinate.latitude, longitude: placeMark.coordinate.longitude)
             let nextVC = FilterViewController()
-            self.navigationController?.pushViewController(nextVC, animated: true)
+            self?.navigationController?.pushViewController(nextVC, animated: true)
         }
 
     }

--- a/Airbnb/Airbnb/Screens/Search/View/SearchViewController.swift
+++ b/Airbnb/Airbnb/Screens/Search/View/SearchViewController.swift
@@ -140,12 +140,10 @@ extension SearchViewController: UICollectionViewDelegate {
         search.start { [weak self] (response, error) in
             guard error == nil else {return}
             guard let placeMark = response?.mapItems[0].placemark, let title = placeMark.title else {return}
-
             let location = Location(name: title, latitude: placeMark.coordinate.latitude, longitude: placeMark.coordinate.longitude)
             let filterViewModel = FilterViewModel()
             filterViewModel.location.value = location
             let nextVC = FilterViewController(filterViewModel: filterViewModel)
-
             self?.navigationController?.pushViewController(nextVC, animated: true)
         }
 

--- a/Airbnb/Airbnb/Screens/TabBarController.swift
+++ b/Airbnb/Airbnb/Screens/TabBarController.swift
@@ -1,0 +1,38 @@
+//
+//  TabBarController.swift
+//  Airbnb
+//
+//  Created by Kai Kim on 2022/06/02.
+//
+
+import UIKit
+
+final class TabBarController: UITabBarController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureDisplay()
+        configureLayout()
+    }
+
+    private func configureDisplay () {
+        let homeViewController =  UINavigationController(rootViewController: HomeViewController())
+        let wishListViewController = UIViewController()
+        let reservationViewController = UIViewController()
+        wishListViewController.view.backgroundColor = .primary
+        reservationViewController.view.backgroundColor = .orange
+        homeViewController.tabBarItem = UITabBarItem(title: "검색", image: UIImage(named: "search"), tag: 0)
+        wishListViewController.tabBarItem = UITabBarItem(title: "위시리스트", image: UIImage(named: "like"), tag: 1)
+        reservationViewController.tabBarItem = UITabBarItem(title: "내 예약", image: UIImage(named: "profile"), tag: 2)
+        self.setViewControllers([homeViewController, wishListViewController, reservationViewController], animated: false)
+        tabBar.backgroundColor = .gray6
+        tabBar.tintColor = .gray1
+    }
+
+    private func configureLayout() {
+        let lineView = UIView(frame: CGRect(x: 0, y: 0, width: tabBar.frame.size.width, height: 1))
+        lineView.backgroundColor = .gray4
+        tabBar.addSubview(lineView)
+    }
+
+}

--- a/Airbnb/Airbnb/Support/SceneDelegate.swift
+++ b/Airbnb/Airbnb/Support/SceneDelegate.swift
@@ -15,31 +15,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
-
-        let homeViewController =  UINavigationController(rootViewController: HomeViewController())
-        let wishListViewController = UIViewController()
-        wishListViewController.view.backgroundColor = .primary
-        let reservationViewController = UIViewController()
-        reservationViewController.view.backgroundColor = .orange
-
-        let tabVC =  UITabBarController()
-        tabVC.setViewControllers([homeViewController, wishListViewController, reservationViewController], animated: false)
-
-        homeViewController.tabBarItem = UITabBarItem(title: "검색", image: UIImage(named: "search"), tag: 0)
-        wishListViewController.tabBarItem = UITabBarItem(title: "위시리스트", image: UIImage(named: "like"), tag: 1)
-        reservationViewController.tabBarItem = UITabBarItem(title: "내 예약", image: UIImage(named: "profile"), tag: 2)
-
-        tabVC.tabBar.backgroundColor = .gray6
-        tabVC.tabBar.tintColor = .gray1
-
-        let lineView = UIView(frame: CGRect(x: 0, y: 0, width: tabVC.tabBar.frame.size.width, height: 1))
-        lineView.backgroundColor = .gray4
-        tabVC.tabBar.addSubview(lineView)
-
+        let tabVC = TabBarController()
         window.rootViewController = tabVC
         window.makeKeyAndVisible()
         self.window = window
-
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## 🧑🏼‍💻 작업 목록
- [X] 검색화면 데이터 바인딩을 담당해주는 `FilterViewModel` 구현 
- [X] ToolBar 를 이용하여 검색화면 하단 탭 구현

## 🤔 고민과 해결

### 1.0 `SearchViewController` 에서 선택된 도시의 정보를 `FilterViewController` 에게 전달하기
> `filterViewController` 의 생성자 안에 매개변수로 `FilterViewModel` 을 넣어서 생성하도록 했습니다. 
    
### 2.0 `FilterViewController` 의 데이터들 (선택된 도시, 가격, 인원 등) 이 변화가 있을시 어떻게 관리(저장 및 업데이트)하고 어떻게 Cell 에 원하는 정보만 뿌려줄지.
>    - 도시, 가격, 인원 의 정보를 담을 각각의 Model 을 만들었습니다.
>    - `FilterViewModel` 은 각각의 모델을 observable 한 프로퍼티로 가지고 있습니다. 변화가 있을시 `FilterViewController` 의 binding 하는 부분에서 해당 모델로 `listCellViewModel` 을 업데이트 한뒤 collectionView 를reload 합니다.
    
### 3.0 숙소찾기 하단 탭 구현
>    - 현재 임배드 되어 있는 TabBar 의 tab Item 을 바꿔주면 되겠다는 생각이 들었는데 tabBar 는 앱 상의 다른 화면으로 전환 시켜줄때 사용되는것을 알게 됐습니다. 숙소찾기에 요구되는 하단탭의 요구사항은 현재 뷰에 있는 요소들에 관련이 있는것이기 때문에 toolBar 를 사용하는것이 더 적절하다고 생각이 들었습니다.
>    - 따라서 TabBar 를 `FilterViewController` 가 viewDidLoad 되는 시점에 tabBar 를 disable 시키고 다른 ViewController 로 전환 되기전 의 시점인 viewWillDisappear 에서 tabBar 를 다시 able 시켜주었습니다.
>    - 그리고 toolBar 를 생성하여 원래 tabBar 가 위치해 있던 자리에 배치해주었습니다.

## 💭 남겨진 고민들..
> - `filterViewController` 의 `UICollectionViewDataSource` 의`numberOfSections` 부분에 하드코딩한부분을 어떻게 바꾸어줄지 고민입니다. ViewModel 에서 값을주어야한다고 생각하는데  구조를 잘못 짜서 그런지 하드코딩 외 다른방법이 떠오르지 않습니다..
> - 체크인/체크아웃, 가격조정, 인원수 화면 에서 사용자 입력을 받으면 해당 리스트 를 업데이트 해주고 toolBar 의 버튼 의 활성/비활성 화 의 흐름을 어떻게 짜주어야할지 고민입니다.

## 📺 구현 화면
![PR4](https://user-images.githubusercontent.com/36659877/171790197-33cc6106-88d7-4558-be9d-6faea5bd4609.gif)

