### PR TITLE
[Team-01] [FE/호이] 2주차 두번째 PR

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -18,6 +18,7 @@
         "@types/styled-components": "^5.1.25",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",
         "styled-reset": "^4.4.1",
@@ -8230,6 +8231,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -13649,6 +13658,30 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -22353,6 +22386,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -26134,6 +26175,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/fe/package.json
+++ b/fe/package.json
@@ -13,6 +13,7 @@
     "@types/styled-components": "^5.1.25",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.1",

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -3,7 +3,9 @@ import HeadCountProvider from "Context/HeadCountProvider";
 import GlobalStyle from "Helpers/globalStyle";
 import { composeProvider } from "Helpers/utils";
 import Home from "Pages/Home/Home";
-import React from "react";
+import NotFound from "Pages/NotFound/NotFound";
+import SearchResult from "Pages/SearchResult/SearchResult";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 const providerList = [CalendarProvider, HeadCountProvider];
 
@@ -14,7 +16,13 @@ function App() {
     <div className="App">
       <GlobalStyle />
       <Provider>
-        <Home />
+        <BrowserRouter basename={process.env.PUBLIC_URL}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/searchResult" element={<SearchResult />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
       </Provider>
     </div>
   );

--- a/fe/src/Components/Calendar/Calendar.styled.ts
+++ b/fe/src/Components/Calendar/Calendar.styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 interface CalendarContainerType {
   columnCount?: number;
-  calendarModalStyle?: string;
+  calendarStyle?: string;
 }
 
 export const CalendarContainer = styled.div<CalendarContainerType>`
@@ -13,7 +13,7 @@ export const CalendarContainer = styled.div<CalendarContainerType>`
 
   grid-template-rows: repeat(1, 1fr);
   grid-auto-rows: 1fr;
-  ${({ calendarModalStyle }) => {
-    return calendarModalStyle ? calendarModalStyle : "";
+  ${({ calendarStyle }) => {
+    return calendarStyle ? calendarStyle : "";
   }};
 `;

--- a/fe/src/Components/Calendar/Calendar.tsx
+++ b/fe/src/Components/Calendar/Calendar.tsx
@@ -13,7 +13,7 @@ interface CalendarDateType {
 interface CalendarType {
   calendarShowCount?: number;
   columnCount?: number;
-  calendarModalStyle?: string;
+  calendarStyle?: string;
   checkIn?: DateType;
   checkOut?: DateType;
   calendarData: CalendarDateType;
@@ -42,7 +42,7 @@ const getNextMonthInfo = ({ prevMonth, prevYear }: MonthInfoType) => {
 export default function Calendar({
   calendarShowCount,
   columnCount,
-  calendarModalStyle,
+  calendarStyle,
   checkIn,
   checkOut,
   calendarData,
@@ -107,7 +107,7 @@ export default function Calendar({
     <CalendarContainer
       ref={(el) => calendarRef && (calendarRef.current[MODAL_REF_IDX] = el)}
       columnCount={columnCount}
-      calendarModalStyle={calendarModalStyle}
+      calendarStyle={calendarStyle}
     >
       {firstCalendar}
       {nextCalendar}

--- a/fe/src/Components/Calendar/Month/Month.styled.ts
+++ b/fe/src/Components/Calendar/Month/Month.styled.ts
@@ -1,4 +1,5 @@
-import { applyFlex, FlexBoxType } from "Helpers/utils";
+import { FlexType } from "Helpers/interface";
+import { applyFlex } from "Helpers/utils";
 import styled from "styled-components";
 
 interface ButtonType {
@@ -10,7 +11,7 @@ export const Monthly = styled.div`
 `;
 
 export const YearMonthArea = styled.div`
-  ${({ flex, justify }: FlexBoxType) => applyFlex({ flex, justify })};
+  ${({ flex, justify }: FlexType) => applyFlex({ flex, justify })};
   width: 90%;
   height: 40px;
   margin-bottom: 40px;

--- a/fe/src/Components/Gnb/Gnb.styled.ts
+++ b/fe/src/Components/Gnb/Gnb.styled.ts
@@ -1,13 +1,14 @@
-import { applyFlex, FlexBoxType } from "Helpers/utils";
+import { applyFlex } from "Helpers/utils";
+import { FlexType } from "Helpers/interface";
 import styled from "styled-components";
 
 export const Container = styled.div`
-  ${({ flex, justify }: FlexBoxType) => applyFlex({ flex, justify })};
+  ${({ flex, justify }: FlexType) => applyFlex({ flex, justify })};
   padding: 24px 0;
 `;
 
 export const Menus = styled.ul`
-  ${({ flex }: FlexBoxType) => applyFlex({ flex })};
+  ${({ flex }: FlexType) => applyFlex({ flex })};
   padding: 12px 0;
   font-size: 16px;
 `;
@@ -23,7 +24,7 @@ export const Buttons = styled.ul`
   width: 76px;
   height: 40px;
   border-radius: 30px;
-  ${({ flex, justify, align }: FlexBoxType) => applyFlex({ flex, justify, align })}
+  ${({ flex, justify, align }: FlexType) => applyFlex({ flex, justify, align })}
 `;
 
 export const Logo = styled.div`

--- a/fe/src/Components/Gnb/Gnb.tsx
+++ b/fe/src/Components/Gnb/Gnb.tsx
@@ -3,12 +3,15 @@ import drawerMenu from "Asset/drawerMenu.svg";
 import logo from "Asset/logo.svg";
 import { Buttons, Container, Logo, Menu, Menus } from "Components/Gnb/Gnb.styled";
 import { Img } from "Components/Common/styled";
+import { NavLink } from "react-router-dom";
 
 export default function Gnb() {
   return (
     <Container flex={true} justify="space-between">
       <Logo>
-        <Img src={logo} width="88px" height="46px" />
+        <NavLink to="/">
+          <Img src={logo} width="88px" height="46px" />
+        </NavLink>
       </Logo>
       <Menus flex={true}>
         <Menu>숙소</Menu>

--- a/fe/src/Components/Gnb/Gnb.tsx
+++ b/fe/src/Components/Gnb/Gnb.tsx
@@ -5,7 +5,11 @@ import { Buttons, Container, Logo, Menu, Menus } from "Components/Gnb/Gnb.styled
 import { Img } from "Components/Common/styled";
 import { NavLink } from "react-router-dom";
 
-export default function Gnb() {
+interface GnBType {
+  contents?: any;
+}
+
+export default function Gnb({ contents }: GnBType) {
   return (
     <Container flex={true} justify="space-between">
       <Logo>
@@ -13,11 +17,15 @@ export default function Gnb() {
           <Img src={logo} width="88px" height="46px" />
         </NavLink>
       </Logo>
-      <Menus flex={true}>
-        <Menu>숙소</Menu>
-        <Menu>체험</Menu>
-        <Menu>온라인 체험</Menu>
-      </Menus>
+      {contents ? (
+        contents
+      ) : (
+        <Menus flex={true}>
+          <Menu>숙소</Menu>
+          <Menu>체험</Menu>
+          <Menu>온라인 체험</Menu>
+        </Menus>
+      )}
       <Buttons flex={true} justify="center" align="center">
         <Img src={drawerMenu} width="18px" height="18px" alt="메뉴" />
         <Img src={userImg} width="32px" height="32px" alt="로그인" />

--- a/fe/src/Components/HeadCount/HeadCount.styled.ts
+++ b/fe/src/Components/HeadCount/HeadCount.styled.ts
@@ -6,6 +6,6 @@ interface styleType {
 
 export const HeadCountContainer = styled.div<styleType>`
   ${({ containerStyle }) => {
-    return containerStyle ? containerStyle : "";
+    return containerStyle || "";
   }};
 `;

--- a/fe/src/Components/HeadCount/HeadCount.tsx
+++ b/fe/src/Components/HeadCount/HeadCount.tsx
@@ -21,6 +21,7 @@ interface StateType {
 }
 
 interface HeadCountType {
+  headCountStyle?: string;
   headCountRef?: React.MutableRefObject<HTMLElement[] | null[]>;
   headCountState?: StateType;
   handleClick?: (T: ClickEventType) => void;
@@ -42,21 +43,16 @@ const babyInfo: InfoType = {
   classification: "baby",
 };
 
-const containerStyle = `
-  width:400px;
-  height:355px;
-  background-color:#fff;
-  border-radius:40px;
-  margin-top:16px;
-  margin-left:778px;
-  padding:64px;
-`;
-
-export default function HeadCount({ headCountRef, headCountState, handleClick }: HeadCountType) {
+export default function HeadCount({
+  headCountRef,
+  headCountState,
+  handleClick,
+  headCountStyle,
+}: HeadCountType) {
   return (
     <HeadCountContainer
       ref={(el) => headCountRef && (headCountRef.current[MODAL_REF_IDX] = el)}
-      containerStyle={containerStyle}
+      containerStyle={headCountStyle}
     >
       <TicketBox handleClick={handleClick} headCountState={headCountState} contents={adultInfo}></TicketBox>
       <TicketBox handleClick={handleClick} headCountState={headCountState} contents={childInfo}></TicketBox>

--- a/fe/src/Components/SearchBar/MiniSearchBar.tsx
+++ b/fe/src/Components/SearchBar/MiniSearchBar.tsx
@@ -1,0 +1,77 @@
+import { Img } from "Components/Common/styled";
+import cancelButton from "Asset/cancelButton.svg";
+import { CalendarContext } from "Context/CalendarProvider";
+import { HeadCountContext } from "Context/HeadCountProvider";
+import { useContext } from "react";
+import {
+  ActiveContent,
+  Container,
+  ContentContainer,
+  ContentHeader,
+  DateArea,
+  HeadCountArea,
+  InActiveContent,
+  PriceArea,
+} from "./SearchBar.styled";
+
+interface MiniSearchBarType {
+  searchBarStyle?: string;
+  handleClick?: () => void;
+  calendarRef?: React.MutableRefObject<HTMLElement[] | null[]>;
+  headCountRef?: React.MutableRefObject<HTMLElement[] | null[]>;
+}
+
+export default function MiniSearchBar({ searchBarStyle, handleClick }: MiniSearchBarType) {
+  const calendarState: any = useContext(CalendarContext);
+  const headCountState: any = useContext(HeadCountContext);
+
+  const { checkIn, checkOut } = calendarState;
+  const { adult, child, baby } = headCountState;
+  const guestCount = adult + child;
+  const headCountTemplate = `게스트 ${guestCount}명 ${baby > 0 ? `유아 ${baby}명` : ""}`;
+  const { month: checkInMonth, day: checkInDay } = checkIn;
+  const { month: checkOutMonth, day: checkOutDay } = checkOut;
+
+  return (
+    <Container flex={true} justify="space-between" searchBarStyle={searchBarStyle} onClick={handleClick}>
+      <DateArea flex={true} justify="space-between" align="center">
+        <ContentContainer>
+          {checkInDay > 0 ? (
+            <ActiveContent>{`${checkInMonth}월 ${checkInDay}일`}</ActiveContent>
+          ) : (
+            <InActiveContent>날짜입력</InActiveContent>
+          )}
+        </ContentContainer>
+        <ContentContainer>
+          {checkOutDay > 0 ? (
+            <ActiveContent>{`${checkOutMonth}월 ${checkOutDay}일`}</ActiveContent>
+          ) : (
+            <InActiveContent>날짜입력</InActiveContent>
+          )}
+        </ContentContainer>
+      </DateArea>
+      <PriceArea flex={true} justify="space-between" align="center">
+        <ContentContainer>
+          <ContentHeader>요금</ContentHeader>
+          {/* 금액 상태 값이 입력되면 Active, 없으면 InActive */}
+          {false ? (
+            <ActiveContent>입력된 금액</ActiveContent>
+          ) : (
+            <InActiveContent>금액대 설정</InActiveContent>
+          )}
+        </ContentContainer>
+        <Img src={cancelButton} width="20px" height="20px" margin="0 33px 0 0" />
+      </PriceArea>
+      <HeadCountArea flex={true} justify="space-between" align="center">
+        <ContentContainer width="140px">
+          <ContentHeader>인원 수</ContentHeader>
+          {guestCount > 0 ? (
+            <ActiveContent>{headCountTemplate}</ActiveContent>
+          ) : (
+            <InActiveContent>게스트 추가</InActiveContent>
+          )}
+        </ContentContainer>
+      </HeadCountArea>
+    </Container>
+  );
+}

--- a/fe/src/Components/SearchBar/SearchBar.styled.ts
+++ b/fe/src/Components/SearchBar/SearchBar.styled.ts
@@ -56,3 +56,8 @@ export const ContentHeader = styled.header`
   line-height: 17px;
   margin-bottom: 4px;
 `;
+
+export const SearchButtonArea = styled.div`
+  position: absolute;
+  right: 20px;
+`;

--- a/fe/src/Components/SearchBar/SearchBar.styled.ts
+++ b/fe/src/Components/SearchBar/SearchBar.styled.ts
@@ -1,4 +1,5 @@
-import { applyFlex, FlexBoxType } from "Helpers/utils";
+import { FlexType, SearchBarContainerType } from "Helpers/interface";
+import { applyFlex } from "Helpers/utils";
 import styled from "styled-components";
 
 interface ContentContainerType {
@@ -6,30 +7,25 @@ interface ContentContainerType {
 }
 
 export const Container = styled.div`
-  ${({ flex, justify }: FlexBoxType) => applyFlex({ flex, justify })};
-  width: 916px;
-  height: 76px;
-  margin-top: 110px;
-  margin-left: 262px;
-  background-color: #fff;
-  border-radius: 30px;
-  padding: 16px;
+  ${({ flex, justify }: SearchBarContainerType) => applyFlex({ flex, justify })};
+  position: relative;
+  ${({ searchBarStyle }: SearchBarContainerType) => searchBarStyle};
 `;
 
 export const DateArea = styled.div`
-  ${({ flex, align }: FlexBoxType) => applyFlex({ flex, align })};
+  ${({ flex, align }: FlexType) => applyFlex({ flex, align })};
   width: 330px;
   border-right: 1px solid #e0e0e0;
 `;
 
 export const PriceArea = styled.div`
-  ${({ flex, justify, align }: FlexBoxType) => applyFlex({ flex, justify, align })};
+  ${({ flex, justify, align }: FlexType) => applyFlex({ flex, justify, align })};
   width: 250px;
   border-right: 1px solid #e0e0e0;
 `;
 
 export const HeadCountArea = styled.div`
-  ${({ flex, justify, align }: FlexBoxType) => applyFlex({ flex, justify, align })};
+  ${({ flex, justify, align }: FlexType) => applyFlex({ flex, justify, align })};
   width: 298px;
 `;
 
@@ -38,7 +34,7 @@ export const SearchButton = styled.div`
   height: 40px;
   background: #e84c60;
   border-radius: 30px;
-  ${({ flex, align }: FlexBoxType) => applyFlex({ flex, align })}
+  ${({ flex, align }: FlexType) => applyFlex({ flex, align })}
 `;
 
 export const ActiveContent = styled.div`

--- a/fe/src/Components/SearchBar/SearchBar.tsx
+++ b/fe/src/Components/SearchBar/SearchBar.tsx
@@ -12,9 +12,9 @@ import cancelButton from "Asset/cancelButton.svg";
 import searchButton from "Asset/searchButton.svg";
 import activeSearchButton from "Asset/activeSearchButton.svg";
 import { Img } from "Components/Common/styled";
-import { useCalendar } from "Hook/useCalendar";
 import { SEARCH_BAR_REF_IDX } from "Helpers/constant";
 import { useHeadCount } from "Context/HeadCountProvider";
+import { useCalendar } from "Context/CalendarProvider";
 
 interface SearchBarType {
   calendarRef?: React.MutableRefObject<HTMLElement[] | null[]>;
@@ -28,8 +28,7 @@ export default function SearchBar({ calendarRef, headCountRef }: SearchBarType) 
   const { isHeadCountOpen, adult, child, baby: babyCount } = headCountState;
   const guestCount = adult + child;
 
-  const headCountTemplate =
-    babyCount > 0 ? `게스트 ${guestCount}명 유아 ${babyCount}명` : `게스트 ${guestCount}명`;
+  const headCountTemplate = `게스트 ${guestCount}명 ${babyCount > 0 ? `유아 ${babyCount}명` : ""}`;
 
   const { isCalendarOpen, checkIn, checkOut } = calendarState;
 
@@ -68,7 +67,7 @@ export default function SearchBar({ calendarRef, headCountRef }: SearchBarType) 
             <InActiveContent>날짜입력</InActiveContent>
           )}
         </ContentContainer>
-        {checkIn.day > 0 && checkOut.day > 0 && (
+        {isCalendarOpen && (
           <Img
             src={cancelButton}
             width="20px"
@@ -104,7 +103,7 @@ export default function SearchBar({ calendarRef, headCountRef }: SearchBarType) 
             <InActiveContent>게스트 추가</InActiveContent>
           )}
         </ContentContainer>
-        {guestCount > 0 && (
+        {isHeadCountOpen && (
           <Img src={cancelButton} width="20px" height="20px" onClick={() => handleReset(dispatchHeadCount)} />
         )}
         {isSearchBarOpen ? (

--- a/fe/src/Components/SearchBar/SearchBar.tsx
+++ b/fe/src/Components/SearchBar/SearchBar.tsx
@@ -7,6 +7,7 @@ import {
   ActiveContent,
   ContentHeader,
   ContentContainer,
+  SearchButtonArea,
 } from "./SearchBar.styled";
 import cancelButton from "Asset/cancelButton.svg";
 import searchButton from "Asset/searchButton.svg";
@@ -15,8 +16,10 @@ import { Img } from "Components/Common/styled";
 import { SEARCH_BAR_REF_IDX } from "Helpers/constant";
 import { useHeadCount } from "Context/HeadCountProvider";
 import { useCalendar } from "Context/CalendarProvider";
+import { NavLink } from "react-router-dom";
 
 interface SearchBarType {
+  searchBarStyle?: string;
   calendarRef?: React.MutableRefObject<HTMLElement[] | null[]>;
   headCountRef?: React.MutableRefObject<HTMLElement[] | null[]>;
 }
@@ -104,14 +107,24 @@ export default function SearchBar({ calendarRef, headCountRef, searchBarStyle }:
           )}
         </ContentContainer>
         {isHeadCountOpen && (
-          <Img src={cancelButton} width="20px" height="20px" onClick={() => handleReset(dispatchHeadCount)} />
-        )}
-        {isSearchBarOpen ? (
-          <Img src={activeSearchButton} width="90px" height="42px" />
-        ) : (
-          <Img src={searchButton} width="40px" height="40px" />
+          <Img
+            src={cancelButton}
+            width="20px"
+            height="20px"
+            margin="0 100px 0 0"
+            onClick={() => handleReset(dispatchHeadCount)}
+          />
         )}
       </HeadCountArea>
+      <SearchButtonArea>
+        <NavLink to="/searchResult">
+          {isSearchBarOpen ? (
+            <Img src={activeSearchButton} width="90px" height="42px" />
+          ) : (
+            <Img src={searchButton} width="40px" height="40px" />
+          )}
+        </NavLink>
+      </SearchButtonArea>
     </Container>
   );
 }

--- a/fe/src/Components/SearchBar/SearchBar.tsx
+++ b/fe/src/Components/SearchBar/SearchBar.tsx
@@ -21,7 +21,7 @@ interface SearchBarType {
   headCountRef?: React.MutableRefObject<HTMLElement[] | null[]>;
 }
 
-export default function SearchBar({ calendarRef, headCountRef }: SearchBarType) {
+export default function SearchBar({ calendarRef, headCountRef, searchBarStyle }: SearchBarType) {
   const [calendarState, dispatchCalendar] = useCalendar();
   const [headCountState, dispatchHeadCount] = useHeadCount();
 
@@ -44,7 +44,7 @@ export default function SearchBar({ calendarRef, headCountRef }: SearchBarType) 
   };
 
   return (
-    <Container flex={true} justify="space-between">
+    <Container flex={true} justify="space-between" searchBarStyle={searchBarStyle}>
       <DateArea
         ref={(el) => calendarRef && (calendarRef.current[SEARCH_BAR_REF_IDX] = el)}
         flex={true}

--- a/fe/src/Context/CalendarProvider.tsx
+++ b/fe/src/Context/CalendarProvider.tsx
@@ -1,5 +1,5 @@
 import { useCalendarReducer } from "Hook/useCalendar";
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 
 // interface actionType {
 //   type: "OPEN" | "CLOSE" | "SET_CHECK_IN" | "SET_CHECK_OUT";
@@ -22,3 +22,5 @@ export default function CalendarProvider({ children }: any) {
     </DispatchCalendarContext.Provider>
   );
 }
+
+export const useCalendar = () => [useContext(CalendarContext), useContext(DispatchCalendarContext)];

--- a/fe/src/Context/CalendarProvider.tsx
+++ b/fe/src/Context/CalendarProvider.tsx
@@ -10,7 +10,7 @@ import { createContext, useContext } from "react";
 // Dispatch 타입, children 타입 보류중
 // Children : React.ReactNode 왜 안될까?
 
-export const CalendarContext = createContext({});
+export const CalendarContext: React.Context<{}> = createContext({});
 export const DispatchCalendarContext = createContext<any>(undefined);
 
 export default function CalendarProvider({ children }: any) {

--- a/fe/src/Helpers/interface.ts
+++ b/fe/src/Helpers/interface.ts
@@ -8,10 +8,18 @@ export interface EventType {
   target: any;
 }
 
-export interface FlexType {
-  flex: boolean;
+export interface FlexBoxPropertyType {
   justify?: string;
   align?: string;
   direction?: string;
   wrap?: string;
+  grow?: string;
+}
+
+export interface FlexType extends FlexBoxPropertyType {
+  flex: boolean;
+}
+
+export interface SearchBarContainerType extends FlexType {
+  searchBarStyle?: string | undefined;
 }

--- a/fe/src/Helpers/utils.tsx
+++ b/fe/src/Helpers/utils.tsx
@@ -1,20 +1,10 @@
 import { MONTH_DICTIONARY } from "./constant";
+import { FlexBoxPropertyType, FlexType } from "Helpers/interface";
 
-interface FlexBoxPropertyType {
-  justify?: string;
-  align?: string;
-  direction?: string;
-  wrap?: string;
-}
-
-export interface FlexBoxType extends FlexBoxPropertyType {
-  flex: boolean;
-}
-
-export function applyFlex({ flex, justify, align, direction, wrap }: FlexBoxType) {
+export function applyFlex({ flex, justify, align, direction, wrap, grow }: FlexType) {
   return (
     flex &&
-    `${getFlexTemplate({ justify, align, direction, wrap })}
+    `${getFlexTemplate({ justify, align, direction, wrap, grow })}
     `
   );
 }
@@ -24,6 +14,7 @@ function getFlexTemplate({
   align = "stretch",
   direction = "row",
   wrap = "nowrap",
+  grow = "0",
 }: FlexBoxPropertyType) {
   return `
     display: flex;
@@ -31,6 +22,7 @@ function getFlexTemplate({
     align-items: ${align};
     flex-direction: ${direction};
     flex-wrap:${wrap}
+    flex-grow:${grow}
   `;
 }
 

--- a/fe/src/Hook/useCalendar.ts
+++ b/fe/src/Hook/useCalendar.ts
@@ -1,5 +1,4 @@
-import { CalendarContext, DispatchCalendarContext } from "Context/CalendarProvider";
-import { useContext, useReducer } from "react";
+import { useReducer } from "react";
 
 interface ActionType {
   type: string;
@@ -57,11 +56,17 @@ const reducer = (state: object, action: ActionType) => {
         ...initialState,
         isCalendarOpen: true,
       };
+    case "RESET_CHECK_IN":
+      console.log("??");
+      return {
+        ...state,
+        checkIn: {
+          ...initialState.checkIn,
+        },
+      };
     default:
       return state;
   }
 };
 
 export const useCalendarReducer = () => useReducer(reducer, initialState);
-
-export const useCalendar = () => [useContext(CalendarContext), useContext(DispatchCalendarContext)];

--- a/fe/src/Hook/useCalendar.ts
+++ b/fe/src/Hook/useCalendar.ts
@@ -7,7 +7,13 @@ interface ActionType {
   day?: number;
 }
 
-const initialState = {
+interface CalendarStateType {
+  isCalendarOpen: boolean;
+  checkIn: object;
+  checkOut: object;
+}
+
+const initialState: CalendarStateType = {
   isCalendarOpen: false,
   checkIn: {
     year: 0,
@@ -57,7 +63,6 @@ const reducer = (state: object, action: ActionType) => {
         isCalendarOpen: true,
       };
     case "RESET_CHECK_IN":
-      console.log("??");
       return {
         ...state,
         checkIn: {

--- a/fe/src/Hook/useOutsideClick.ts
+++ b/fe/src/Hook/useOutsideClick.ts
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 
-export function useOutsideClick(elements: any, callback: any) {
+export function useOutsideClick(elements: React.MutableRefObject<HTMLElement[]>, callback: () => void) {
   useEffect(() => {
-    const handleMouseDown = (event: any) => {
+    const handleMouseDown = ({ target }: any) => {
       for (let element of elements.current) {
         // undefined: 모달은 활성화 되어 있지만, 버튼은 비활성화 상태일때는 함수를 탈출하지 않는다.
         if (element === undefined) {
@@ -10,7 +10,7 @@ export function useOutsideClick(elements: any, callback: any) {
         }
 
         // 모달이 비활성화(Null) 또는 모달(또는 버튼) 내부 클릭일 경우 콜백 함수를 실행하지 않는다.
-        if (element === null || element.contains(event.target)) {
+        if (element === null || element.contains(target)) {
           return;
         }
       }

--- a/fe/src/Pages/Common/CalendarModal/CalendarModal.tsx
+++ b/fe/src/Pages/Common/CalendarModal/CalendarModal.tsx
@@ -15,20 +15,11 @@ interface dispatchType extends DateType {
 
 const { year: initYear, month: initMonth } = getTodayDate();
 
-export default function CalendarModal({ calendarRef }: any) {
+export default function CalendarModal({ calendarRef, calendarStyle }: any) {
   const [calendarData, setCalendarData] = useState({ year: initYear, month: initMonth });
   const [calendarState, dispatchCalendar] = useCalendar();
 
   const { checkIn, checkOut, isCalendarOpen } = calendarState;
-
-  const calendarModalStyle = `
-    background-color:#fff;
-    width: 916px;
-    margin-left: 262px;
-    margin-top: 40px;
-    padding: 88px;
-    border-radius: 40px;
-  `;
   const calendarShowCount = 2;
 
   const runDispatchCalendar = ({ year, month, day, type }: dispatchType) => {
@@ -90,7 +81,7 @@ export default function CalendarModal({ calendarRef }: any) {
         calendarRef={calendarRef}
         calendarShowCount={calendarShowCount}
         columnCount={2}
-        calendarModalStyle={calendarModalStyle}
+        calendarStyle={calendarStyle}
         checkIn={checkIn}
         checkOut={checkOut}
         calendarData={calendarData}

--- a/fe/src/Pages/Common/HeadCountModal/HeadCountModal.tsx
+++ b/fe/src/Pages/Common/HeadCountModal/HeadCountModal.tsx
@@ -7,7 +7,7 @@ interface ClickEventType {
   target: string | undefined;
 }
 
-export default function HeadCountModal({ headCountRef }: any) {
+export default function HeadCountModal({ headCountRef, headCountStyle }: any) {
   const [headCountState, dispatchHeadCount] = useHeadCount();
   const { isHeadCountOpen } = headCountState;
 
@@ -29,7 +29,12 @@ export default function HeadCountModal({ headCountRef }: any) {
 
   return (
     isHeadCountOpen && (
-      <HeadCount headCountRef={headCountRef} headCountState={headCountState} handleClick={handleClick} />
+      <HeadCount
+        headCountRef={headCountRef}
+        headCountState={headCountState}
+        handleClick={handleClick}
+        headCountStyle={headCountStyle}
+      />
     )
   );
 }

--- a/fe/src/Pages/Common/SearchView.styled.ts
+++ b/fe/src/Pages/Common/SearchView.styled.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const SearchViewContainer = styled.div`
+  width: 916px;
+  margin-top: 20px;
+  z-index: 1;
+`;

--- a/fe/src/Pages/Common/SearchView.tsx
+++ b/fe/src/Pages/Common/SearchView.tsx
@@ -1,4 +1,5 @@
 import SearchBar from "Components/SearchBar/SearchBar";
+import { MODAL_REF_IDX } from "Helpers/constant";
 import CalendarModal from "Pages/Common/CalendarModal/CalendarModal";
 import HeadCountModal from "Pages/Common/HeadCountModal/HeadCountModal";
 import { useRef } from "react";
@@ -7,17 +8,23 @@ interface SearchViewType {
   searchBarStyle?: string;
   calendarStyle?: string;
   headCountStyle?: string;
+  searchRef?: React.MutableRefObject<HTMLElement[] | null[]>;
 }
 
-export default function SearchView({ searchBarStyle, headCountStyle, calendarStyle }: SearchViewType) {
+export default function SearchView({
+  searchRef,
+  searchBarStyle,
+  headCountStyle,
+  calendarStyle,
+}: SearchViewType) {
   const calendarRef = useRef([]);
   const headCountRef = useRef([]);
 
   return (
-    <>
+    <div ref={(el) => searchRef && (searchRef.current[MODAL_REF_IDX] = el)}>
       <SearchBar calendarRef={calendarRef} headCountRef={headCountRef} searchBarStyle={searchBarStyle} />
       <CalendarModal calendarRef={calendarRef} calendarStyle={calendarStyle} />
       <HeadCountModal headCountRef={headCountRef} headCountStyle={headCountStyle} />
-    </>
+    </div>
   );
 }

--- a/fe/src/Pages/Common/SearchView.tsx
+++ b/fe/src/Pages/Common/SearchView.tsx
@@ -3,6 +3,7 @@ import { MODAL_REF_IDX } from "Helpers/constant";
 import CalendarModal from "Pages/Common/CalendarModal/CalendarModal";
 import HeadCountModal from "Pages/Common/HeadCountModal/HeadCountModal";
 import { useRef } from "react";
+import { SearchViewContainer } from "./SearchView.styled";
 
 interface SearchViewType {
   searchBarStyle?: string;
@@ -21,10 +22,10 @@ export default function SearchView({
   const headCountRef = useRef([]);
 
   return (
-    <div ref={(el) => searchRef && (searchRef.current[MODAL_REF_IDX] = el)}>
+    <SearchViewContainer ref={(el) => searchRef && (searchRef.current[MODAL_REF_IDX] = el)}>
       <SearchBar calendarRef={calendarRef} headCountRef={headCountRef} searchBarStyle={searchBarStyle} />
       <CalendarModal calendarRef={calendarRef} calendarStyle={calendarStyle} />
       <HeadCountModal headCountRef={headCountRef} headCountStyle={headCountStyle} />
-    </div>
+    </SearchViewContainer>
   );
 }

--- a/fe/src/Pages/Common/SearchView.tsx
+++ b/fe/src/Pages/Common/SearchView.tsx
@@ -1,0 +1,23 @@
+import SearchBar from "Components/SearchBar/SearchBar";
+import CalendarModal from "Pages/Common/CalendarModal/CalendarModal";
+import HeadCountModal from "Pages/Common/HeadCountModal/HeadCountModal";
+import { useRef } from "react";
+
+interface SearchViewType {
+  searchBarStyle?: string;
+  calendarStyle?: string;
+  headCountStyle?: string;
+}
+
+export default function SearchView({ searchBarStyle, headCountStyle, calendarStyle }: SearchViewType) {
+  const calendarRef = useRef([]);
+  const headCountRef = useRef([]);
+
+  return (
+    <>
+      <SearchBar calendarRef={calendarRef} headCountRef={headCountRef} searchBarStyle={searchBarStyle} />
+      <CalendarModal calendarRef={calendarRef} calendarStyle={calendarStyle} />
+      <HeadCountModal headCountRef={headCountRef} headCountStyle={headCountStyle} />
+    </>
+  );
+}

--- a/fe/src/Pages/Home/CalendarModal/CalendarModal.tsx
+++ b/fe/src/Pages/Home/CalendarModal/CalendarModal.tsx
@@ -2,8 +2,8 @@ import Calendar from "Components/Calendar/Calendar";
 import { getTodayDate } from "Helpers/utils";
 import { useState } from "react";
 import { DateType, EventType } from "Helpers/interface";
-import { useCalendar } from "Hook/useCalendar";
 import { useOutsideClick } from "Hook/useOutsideClick";
+import { useCalendar } from "Context/CalendarProvider";
 
 interface compareCheckInType extends DateType {
   checkIn: DateType;
@@ -110,7 +110,7 @@ const isFasterThanCheckIn = ({ year, day, month, checkIn }: compareCheckInType) 
   if (year === checkIn.year && month < checkIn.month) {
     return true;
   }
-  if (year === checkIn.year && month === checkIn.month && day < checkIn.day) {
+  if (year === checkIn.year && month === checkIn.month && day <= checkIn.day) {
     return true;
   }
   return false;

--- a/fe/src/Pages/Home/Home.styled.tsx
+++ b/fe/src/Pages/Home/Home.styled.tsx
@@ -26,3 +26,31 @@ export const HomeContainer = styled.div`
 export const NearbyTravel = styled.div``;
 
 export const WhereverTravel = styled.div``;
+
+export const searchBarStyle = `
+width: 916px;
+height: 76px;
+margin-top: 110px;
+margin-left: 262px;
+background-color: #fff;
+border-radius: 30px;
+padding: 16px;
+`;
+
+export const headCountStyle = `
+  width:400px;
+  height:355px;
+  background-color:#fff;
+  border-radius:40px;
+  margin-top:16px;
+  margin-left:778px;
+  padding:64px;
+`;
+export const calendarStyle = `
+background-color:#fff;
+width: 916px;
+margin-left: 262px;
+margin-top: 40px;
+padding: 88px;
+border-radius: 40px;
+`;

--- a/fe/src/Pages/Home/Home.tsx
+++ b/fe/src/Pages/Home/Home.tsx
@@ -1,23 +1,27 @@
 import Gnb from "Components/Gnb/Gnb";
-import SearchBar from "Components/SearchBar/SearchBar";
-import { useRef } from "react";
-import { BackgroundImg, HomeContainer, NearbyTravel, WhereverTravel } from "./Home.styled";
-import CalendarModal from "./CalendarModal/CalendarModal";
-import HeadCountModal from "./HeadCountModal/HeadCountModal";
+import SearchView from "Pages/Common/SearchView";
+import {
+  BackgroundImg,
+  calendarStyle,
+  headCountStyle,
+  HomeContainer,
+  NearbyTravel,
+  searchBarStyle,
+  WhereverTravel,
+} from "./Home.styled";
 
 export default function Home() {
-  const calendarRef = useRef([]);
-  const headCountRef = useRef([]);
-
   return (
     <>
       <BackgroundImg url={`${process.env.PUBLIC_URL}/img/banner.png`}>
         <HomeContainer width="1440px" height="640px">
           <div>
             <Gnb />
-            <SearchBar calendarRef={calendarRef} headCountRef={headCountRef} />
-            <CalendarModal calendarRef={calendarRef} />
-            <HeadCountModal headCountRef={headCountRef} />
+            <SearchView
+              searchBarStyle={searchBarStyle}
+              headCountStyle={headCountStyle}
+              calendarStyle={calendarStyle}
+            />
           </div>
         </HomeContainer>
       </BackgroundImg>

--- a/fe/src/Pages/NotFound/NotFound.styled.ts
+++ b/fe/src/Pages/NotFound/NotFound.styled.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+export const NotFoundContainer = styled.div`
+  width: 1060px;
+  height: 1074px;
+  h1 {
+    margin: 40px;
+    font-size: 4rem;
+  }
+  div {
+    margin: 20px;
+    font-size: 2rem;
+  }
+  a {
+    text-decoration: none;
+  }
+`;

--- a/fe/src/Pages/NotFound/NotFound.tsx
+++ b/fe/src/Pages/NotFound/NotFound.tsx
@@ -1,0 +1,14 @@
+import { NavLink } from "react-router-dom";
+import { NotFoundContainer } from "./NotFound.styled";
+
+export default function NotFound() {
+  return (
+    <NotFoundContainer>
+      <h1>404 Not Found</h1>
+      <div>올바른 경로를 입력하세요.</div>
+      <div>
+        홈 : <NavLink to="/">홈으로 바로가기</NavLink>
+      </div>
+    </NotFoundContainer>
+  );
+}

--- a/fe/src/Pages/SearchResult/SearchResult.styled.ts
+++ b/fe/src/Pages/SearchResult/SearchResult.styled.ts
@@ -31,18 +31,18 @@ export const headCountStyle = `
   height:355px;
   background-color:#fff;
   border-radius:40px;
-  margin-top:16px;
+  margin-top:40px;
   margin-left:778px;
   padding:64px;
 `;
 
 export const calendarStyle = `
-background-color:#fff;
-width: 916px;
-margin-left: 262px;
-margin-top: 40px;
-padding: 88px;
-border-radius: 40px;
+  background-color:#fff;
+  width: 916px;
+  margin-left: 262px;
+  margin-top: 40px;
+  padding: 88px;
+  border-radius: 40px;
 `;
 
 export const SearchResultHeader = styled.header`
@@ -52,9 +52,8 @@ export const SearchResultHeader = styled.header`
 `;
 
 export const SearchResultHeaderContainer = styled.div`
-  ${({ isMini }: SearchResultContainerType) => `height:${!isMini ? "120" : "250"}px`};
+  ${({ isMini }: SearchResultContainerType) => `height:${!isMini ? "120" : "240"}px`};
   border-bottom: 1px solid #000;
-  box-shadow: 0px 0px 20px 1px rgb(200, 200, 200);
 `;
 
 export const SearchResultHeaderArea = styled.div`
@@ -68,8 +67,12 @@ export const SearchResultArea = styled.div`
 
 export const Tourist = styled.div`
   flex: 1;
+  height: 1024px;
+  background-color: blue;
 `;
 
 export const Map = styled.div`
   flex: 1;
+  height: 1024px;
+  background-color: green;
 `;

--- a/fe/src/Pages/SearchResult/SearchResult.styled.ts
+++ b/fe/src/Pages/SearchResult/SearchResult.styled.ts
@@ -1,19 +1,35 @@
+import { FlexType } from "Helpers/interface";
+import { applyFlex } from "Helpers/utils";
 import styled from "styled-components";
+
+interface SearchResultContainerType {
+  isMini?: boolean;
+}
+
+export const miniSearchBarStyle = `
+width: 700px;
+height: 76px;
+background-color: #fff;
+border-radius: 30px;
+border:1px solid #000;
+padding: 16px;
+`;
 
 export const searchBarStyle = `
 width: 916px;
 height: 76px;
 margin-top: 20px;
 margin-left: 262px;
-background-color: blue;
+background-color: #fff;
 border-radius: 30px;
+border:1px solid #000;
 padding: 16px;
 `;
 
 export const headCountStyle = `
   width:400px;
   height:355px;
-  background-color:red;
+  background-color:#fff;
   border-radius:40px;
   margin-top:16px;
   margin-left:778px;
@@ -21,7 +37,7 @@ export const headCountStyle = `
 `;
 
 export const calendarStyle = `
-background-color:red;
+background-color:#fff;
 width: 916px;
 margin-left: 262px;
 margin-top: 40px;
@@ -35,9 +51,25 @@ export const SearchResultHeader = styled.header`
   flex-direction: column;
 `;
 
-export const SearchResultContainer = styled.div`
+export const SearchResultHeaderContainer = styled.div`
+  ${({ isMini }: SearchResultContainerType) => `height:${!isMini ? "120" : "250"}px`};
+  border-bottom: 1px solid #000;
+  box-shadow: 0px 0px 20px 1px rgb(200, 200, 200);
+`;
+
+export const SearchResultHeaderArea = styled.div`
   width: 1440px;
-  height: 250px;
   margin: 0 auto;
-  border-bottom: 1px solid red;
+`;
+
+export const SearchResultArea = styled.div`
+  ${({ flex }: FlexType) => applyFlex({ flex })};
+`;
+
+export const Tourist = styled.div`
+  flex: 1;
+`;
+
+export const Map = styled.div`
+  flex: 1;
 `;

--- a/fe/src/Pages/SearchResult/SearchResult.styled.ts
+++ b/fe/src/Pages/SearchResult/SearchResult.styled.ts
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+
+export const searchBarStyle = `
+width: 916px;
+height: 76px;
+margin-top: 20px;
+margin-left: 262px;
+background-color: blue;
+border-radius: 30px;
+padding: 16px;
+`;
+
+export const headCountStyle = `
+  width:400px;
+  height:355px;
+  background-color:red;
+  border-radius:40px;
+  margin-top:16px;
+  margin-left:778px;
+  padding:64px;
+`;
+
+export const calendarStyle = `
+background-color:red;
+width: 916px;
+margin-left: 262px;
+margin-top: 40px;
+padding: 88px;
+border-radius: 40px;
+`;
+
+export const SearchResultHeader = styled.header`
+  height: 30px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SearchResultContainer = styled.div`
+  width: 1440px;
+  height: 250px;
+  margin: 0 auto;
+  border-bottom: 1px solid red;
+`;

--- a/fe/src/Pages/SearchResult/SearchResult.tsx
+++ b/fe/src/Pages/SearchResult/SearchResult.tsx
@@ -1,0 +1,24 @@
+import Gnb from "Components/Gnb/Gnb";
+import SearchView from "Pages/Common/SearchView";
+import {
+  calendarStyle,
+  headCountStyle,
+  searchBarStyle,
+  SearchResultContainer,
+  SearchResultHeader,
+} from "./SearchResult.styled";
+
+export default function SearchResult() {
+  return (
+    <SearchResultContainer className="?">
+      <SearchResultHeader>
+        <Gnb />
+        <SearchView
+          searchBarStyle={searchBarStyle}
+          calendarStyle={calendarStyle}
+          headCountStyle={headCountStyle}
+        />
+      </SearchResultHeader>
+    </SearchResultContainer>
+  );
+}

--- a/fe/src/Pages/SearchResult/SearchResult.tsx
+++ b/fe/src/Pages/SearchResult/SearchResult.tsx
@@ -1,24 +1,62 @@
 import Gnb from "Components/Gnb/Gnb";
+import MiniSearchBar from "Components/SearchBar/MiniSearchBar";
+import { useOutsideClick } from "Hook/useOutsideClick";
 import SearchView from "Pages/Common/SearchView";
+import { useRef, useState } from "react";
 import {
   calendarStyle,
   headCountStyle,
   searchBarStyle,
-  SearchResultContainer,
+  miniSearchBarStyle,
+  SearchResultHeaderArea,
   SearchResultHeader,
+  SearchResultHeaderContainer,
+  SearchResultArea,
+  Tourist,
+  Map,
 } from "./SearchResult.styled";
 
 export default function SearchResult() {
+  const [isMiniSearchBar, setIsMiniSearchBar] = useState(false);
+  const searchRef = useRef([]);
+
+  const handleClick = () => {
+    setIsMiniSearchBar(true);
+  };
+
+  const handleOutsideClick = () => {
+    setIsMiniSearchBar(false);
+  };
+
+  useOutsideClick(searchRef, handleOutsideClick);
+
   return (
-    <SearchResultContainer className="?">
-      <SearchResultHeader>
-        <Gnb />
-        <SearchView
-          searchBarStyle={searchBarStyle}
-          calendarStyle={calendarStyle}
-          headCountStyle={headCountStyle}
-        />
-      </SearchResultHeader>
-    </SearchResultContainer>
+    <>
+      <SearchResultHeaderContainer isMini={isMiniSearchBar}>
+        <SearchResultHeaderArea>
+          <SearchResultHeader>
+            {!isMiniSearchBar ? (
+              <Gnb
+                contents={<MiniSearchBar searchBarStyle={miniSearchBarStyle} handleClick={handleClick} />}
+              />
+            ) : (
+              <>
+                <Gnb />
+                <SearchView
+                  searchRef={searchRef}
+                  searchBarStyle={searchBarStyle}
+                  calendarStyle={calendarStyle}
+                  headCountStyle={headCountStyle}
+                />
+              </>
+            )}
+          </SearchResultHeader>
+        </SearchResultHeaderArea>
+      </SearchResultHeaderContainer>
+      <SearchResultArea flex={true}>
+        <Tourist></Tourist>
+        <Map></Map>
+      </SearchResultArea>
+    </>
   );
 }


### PR DESCRIPTION
안녕하세요! Json. 호이입니다. 🙂
항상 꼼꼼한 리뷰 감사드립니다.

[배포페이지](https://youryu0212.github.io/airbnb/build/)

### 진행 상황

- 검색 결과창 라우터 적용
- 잘못된 주소로 접근시 Not Found 페이지로 이동
- Page/Common 하위에 SearchView, 및 각 영역에 해당하는 Modal을 컴포넌트(Calendar, HeadCount)와 별도로 설정한 이유는 Home, SearchResult에서 서로 다른 style props를 넘겨주는 형태로 재활용 하기 위함
    - ex : home 페이지에서는 검색창에 아무 이벤트가 없지만, searchResult 페이지에서는 검색창 전체에 ref를 걸어서 검색창에 useOutSideClick 훅을 이용해 검색창 외부 클릭시 다시 미니 검색창으로 돌아갈 수 있게 이벤트 핸들링
    - ex : 스타일 다르게 지정 (마진, 패딩, 사이즈 등)
- GNB컴포넌트를 처음 구현할 때 재활용을 고려하지 않았습니다. SearchResult페이지가 생기면서 해당 페이지에서는 미니 검색창을 GNB 컴포넌트 가운데 메뉴를 대신해서 넣어줘야 합니다. 그래서 props를 전달받아서 가운데 메뉴 영역 자리에 넣어줄 수 있도록 GNB 컴포넌트를 수정했습니다.

### 고민거리

- 체크인, 체크아웃, 게스트인원, 요금 등을 context를 이용해 최상단에서 선언한 뒤 루트 페이지와 searchResult 페이지에서 모두 공유할 수 있게 했습니다. 그런데 이 경우 검색을 눌러서 searchResult페이지로 들어간 뒤(첫번째 검색 결과) 다시 홈으로 돌아가서 상태를 변경하고 뒤로가기 버튼을 눌렀을 때, 첫번째 검색 결과가 아닌 변경된 상태에 의존한 검색 결과가 나타나게 됩니다. (상태를 전역에서 공유하고 있으니까) 그렇다면 이 경우는 전역에서 context를 활용하는 것 보다 검색창에서 상태를 정의해둔 뒤 검색 결과창의 경우 queryString을 활용해서 파싱해서 상태를 보여주게 한다면 뒤로가기, 앞으로가기 등에 좀 더 사용성 높은 로직이 될 수 있지 않을까 생각했습니다.
- 타입스크립트, 타입을 선언하는 언어를 처음 사용해보면서 프로젝트에 적용하다보니 적절한 타입을 찾는데 시간이 너무 오래걸렸습니다. 그래서 최대 시간을 짧게 설정해둔 뒤 그 시간동안 타입을 못찾으면 전부 any로 처리했습니다. 우선은 타입스크립트를 사용해보는데 초점을 맞췄고 추후 리팩토링 기회가 된다면 좀 더 적절한 형태로 변경할 계획입니다.

### 다음 진행 예정

- 요금 모달 구현
- api 사용