### PR TITLE
[Team23 땃쥐] airbnb 4차 PR

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -1,6 +1,16 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+
+	//querydsl
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+
 	id 'java'
 }
 
@@ -34,6 +44,10 @@ dependencies {
 	// 쿼리 parameter를 로그로 남김
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
 
+	//querydsl 추가
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
 	//테스트에서 lombok 사용
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
@@ -48,4 +62,24 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// querydsl
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/BE/src/main/java/codesquad/airbnb/accommodation/service/AccommodationCommandService.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/service/AccommodationCommandService.java
@@ -1,5 +1,7 @@
 package codesquad.airbnb.accommodation.service;
 
+import codesquad.airbnb.accommodation.domain.Accommodation;
+import codesquad.airbnb.accommodation.repository.AccommodationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,5 +10,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class AccommodationCommandService {
+
+    private final AccommodationRepository accommodationRepository;
+
+    /**
+     * 숙소 등록
+     */
+    public Long register(Accommodation accommodation) {
+        accommodationRepository.save(accommodation);
+        return accommodation.getId();
+    }
 
 }

--- a/BE/src/main/java/codesquad/airbnb/accommodation/service/AccommodationQueryService.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/service/AccommodationQueryService.java
@@ -1,6 +1,8 @@
 package codesquad.airbnb.accommodation.service;
 
+import codesquad.airbnb.accommodation.domain.Accommodation;
 import codesquad.airbnb.accommodation.repository.AccommodationRepository;
+import codesquad.airbnb.exception.AccommodationNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,4 +14,11 @@ public class AccommodationQueryService {
 
     private final AccommodationRepository accommodationRepository;
 
+    /**
+     * id로 숙소 조회
+     */
+    public Accommodation findById(Long id) {
+        return accommodationRepository.findById(id)
+                .orElseThrow(() -> new AccommodationNotFoundException());
+    }
 }

--- a/BE/src/main/java/codesquad/airbnb/accommodation/web/AccommodationController.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/web/AccommodationController.java
@@ -1,24 +1,40 @@
 package codesquad.airbnb.accommodation.web;
 
+import codesquad.airbnb.accommodation.domain.Accommodation;
 import codesquad.airbnb.accommodation.service.AccommodationCommandService;
 import codesquad.airbnb.accommodation.service.AccommodationQueryService;
+import codesquad.airbnb.accommodation.web.dto.AccommodationDetailResponse;
 import codesquad.airbnb.accommodation.web.dto.AccommodationPricesResponse;
+import codesquad.airbnb.accommodation.web.dto.AccommodationRegisterResponse;
+import codesquad.airbnb.accommodation.web.dto.AccommodationSaveRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/accommodations")
 public class AccommodationController {
 
-    private final AccommodationCommandService accomodationCommandService;
+    private final AccommodationCommandService accommodationCommandService;
     private final AccommodationQueryService accommodationQueryService;
 
-    //TODO: 가격분포 + 숙소 가격 평균
+    @PostMapping
+    public AccommodationRegisterResponse register(@RequestBody AccommodationSaveRequest request) {
+        Accommodation accommodation = request.toEntity();
+        Long accommodationId = accommodationCommandService.register(accommodation);
+        return new AccommodationRegisterResponse(accommodationId);
+    }
+
+    @GetMapping("/{id}")
+    public AccommodationDetailResponse accommodationDetail(@PathVariable Long id) {
+        Accommodation accommodation = accommodationQueryService.findById(id);
+        return AccommodationDetailResponse.create(accommodation);
+    }
+
+    //TODO: 가격 목록 가져오기
     @GetMapping("/prices")
     public AccommodationPricesResponse priceStatistic() {
+        // TODO : AccommodationQueryService에, 가격들 목록을 가져오는 메서드 구현
         return AccommodationPricesResponse.sampleApi();
     }
 }

--- a/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationDetailResponse.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationDetailResponse.java
@@ -1,0 +1,79 @@
+package codesquad.airbnb.accommodation.web.dto;
+
+
+import codesquad.airbnb.accommodation.domain.Accommodation;
+import codesquad.airbnb.accommodation.domain.AccommodationImage;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class AccommodationDetailResponse {
+
+    private Long accommodationId;
+    private String accommodationName;
+    private String description;
+    private Integer limitGuestCount;
+    private Integer pricePerDate;
+    private String locationName;
+    private Double latitude;
+    private Double longitude;
+    private Integer roomCount;
+    private Integer bedCount;
+    private Integer bathRoomCount;
+    private Boolean hasKitchen;
+    private Boolean hasWifi;
+    private Boolean hasAirConditioner;
+    private Boolean hasHairDrier;
+    private List<String> imageUrls;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private AccommodationDetailResponse(Long accommodationId, String accommodationName, String description, Integer limitGuestCount, Integer pricePerDate, String locationName, Double latitude, Double longitude, Integer roomCount, Integer bedCount, Integer bathRoomCount, Boolean hasKitchen, Boolean hasWifi, Boolean hasAirConditioner, Boolean hasHairDrier, List<String> imageUrls) {
+        this.accommodationId = accommodationId;
+        this.accommodationName = accommodationName;
+        this.description = description;
+        this.limitGuestCount = limitGuestCount;
+        this.pricePerDate = pricePerDate;
+        this.locationName = locationName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.roomCount = roomCount;
+        this.bedCount = bedCount;
+        this.bathRoomCount = bathRoomCount;
+        this.hasKitchen = hasKitchen;
+        this.hasWifi = hasWifi;
+        this.hasAirConditioner = hasAirConditioner;
+        this.hasHairDrier = hasHairDrier;
+        this.imageUrls = imageUrls;
+    }
+
+    public static AccommodationDetailResponse create(Accommodation accommodation) {
+        return AccommodationDetailResponse.builder()
+                .accommodationId(accommodation.getId())
+                .accommodationName(accommodation.getName())
+                .description(accommodation.getDescription())
+                .limitGuestCount(accommodation.getLimitGuestCount())
+                .pricePerDate(accommodation.getPricePerDate())
+                .locationName(accommodation.getLocation().getLocationName())
+                .latitude(accommodation.getLocation().getLatitude())
+                .longitude(accommodation.getLocation().getLongitude())
+                .roomCount(accommodation.getFacility().getRoomCount())
+                .bedCount(accommodation.getFacility().getRoomCount())
+                .bathRoomCount(accommodation.getFacility().getBathRoomCount())
+                .hasKitchen(accommodation.getFacility().hasKitchen())
+                .hasWifi(accommodation.getFacility().hasWifi())
+                .hasAirConditioner(accommodation.getFacility().hasAirConditioner())
+                .hasHairDrier(accommodation.getFacility().hasHairDrier())
+                .imageUrls(initImageUrls(accommodation.getImages()))
+                .build();
+    }
+
+    private static List<String> initImageUrls(List<AccommodationImage> images) {
+        return images.stream()
+                .map(AccommodationImage::getUrl)
+                .collect(Collectors.toList());
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationPricesResponse.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationPricesResponse.java
@@ -1,68 +1,31 @@
 package codesquad.airbnb.accommodation.web.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 @Getter
 public class AccommodationPricesResponse {
 
-    /**
-     * 1박 평균 요금
-     */
-    private double priceAverage;
+    private static final int SAMPLE_PRICES_SIZE = 1000;
+    private static final int SAMPLE_GAUSSIAN_AVERAGE = 500000;
+    private static final int SAMPLE_MAX_PRICE_RANGE = 1000000;
 
-    /**
-     * 가격 분포
-     */
-    private int between0kAnd10k;
-    private int between10kAnd20k;
-    private int between20kAnd30k;
-    private int between30kAnd50k;
-    private int between50kAnd70k;
-    private int between70kAnd100k;
-    private int between100kAnd150k;
-    private int between150kAnd200k;
-    private int between200kAnd300k;
-    private int between300kAnd500k;
-    private int between500kAnd700k;
-    private int between700kAnd1000k;
-    private int above1000k;
+    private final List<Integer> prices;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private AccommodationPricesResponse(Double priceAverage, Integer between0kAnd10k, Integer between10kAnd20k, Integer between20kAnd30k, Integer between30kAnd50k, Integer between50kAnd70k, Integer between70kAnd100k, Integer between100kAnd150k, Integer between150kAnd200k, Integer between200kAnd300k, Integer between300kAnd500k, Integer between500kAnd700k, Integer between700kAnd1000k, Integer above1000k) {
-        this.priceAverage = priceAverage;
-        this.between0kAnd10k = between0kAnd10k;
-        this.between10kAnd20k = between10kAnd20k;
-        this.between20kAnd30k = between20kAnd30k;
-        this.between30kAnd50k = between30kAnd50k;
-        this.between50kAnd70k = between50kAnd70k;
-        this.between70kAnd100k = between70kAnd100k;
-        this.between100kAnd150k = between100kAnd150k;
-        this.between150kAnd200k = between150kAnd200k;
-        this.between200kAnd300k = between200kAnd300k;
-        this.between300kAnd500k = between300kAnd500k;
-        this.between500kAnd700k = between500kAnd700k;
-        this.between700kAnd1000k = between700kAnd1000k;
-        this.above1000k = above1000k;
+    private AccommodationPricesResponse(List<Integer> prices) {
+        this.prices = prices;
     }
 
     public static AccommodationPricesResponse sampleApi() {
-        return AccommodationPricesResponse.builder()
-                .priceAverage(165556.3)
-                .between0kAnd10k(0)
-                .between10kAnd20k(5)
-                .between20kAnd30k(12)
-                .between30kAnd50k(20)
-                .between50kAnd70k(30)
-                .between70kAnd100k(15)
-                .between100kAnd150k(7)
-                .between150kAnd200k(3)
-                .between200kAnd300k(2)
-                .between300kAnd500k(1)
-                .between500kAnd700k(0)
-                .between700kAnd1000k(0)
-                .above1000k(0)
-                .build();
+        Random random = new Random();
+        List<Integer> randomPrices = random.ints(1, SAMPLE_MAX_PRICE_RANGE + 1)
+                .limit(SAMPLE_PRICES_SIZE)
+                .boxed()
+                .sorted()
+                .collect(Collectors.toList());
+        return new AccommodationPricesResponse(randomPrices);
     }
 }

--- a/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationRegisterResponse.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationRegisterResponse.java
@@ -1,0 +1,13 @@
+package codesquad.airbnb.accommodation.web.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AccommodationRegisterResponse {
+
+    private Long accommodationId;
+
+    public AccommodationRegisterResponse(Long accommodationId) {
+        this.accommodationId = accommodationId;
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationSaveRequest.java
+++ b/BE/src/main/java/codesquad/airbnb/accommodation/web/dto/AccommodationSaveRequest.java
@@ -1,0 +1,58 @@
+package codesquad.airbnb.accommodation.web.dto;
+
+import codesquad.airbnb.accommodation.domain.Accommodation;
+import codesquad.airbnb.accommodation.domain.Facility;
+import codesquad.airbnb.accommodation.domain.Location;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AccommodationSaveRequest {
+
+    private String name;
+    private String description;
+    private Integer limitGuestCount;
+    private Integer pricePerDate;
+    private String locationName;
+    private Double latitude;
+    private Double longitude;
+    private Integer roomCount;
+    private Integer bedCount;
+    private Integer bathRoomCount;
+    private Boolean hasKitchen;
+    private Boolean hasWifi;
+    private Boolean hasAirConditioner;
+    private Boolean hasHairDrier;
+
+    @Builder
+    public AccommodationSaveRequest(String name, String description, Integer limitGuestCount, Integer pricePerDate, String locationName, Double latitude, Double longitude, Integer roomCount, Integer bedCount, Integer bathRoomCount, Boolean hasKitchen, Boolean hasWifi, Boolean hasAirConditioner, Boolean hasHairDrier) {
+        this.name = name;
+        this.description = description;
+        this.limitGuestCount = limitGuestCount;
+        this.pricePerDate = pricePerDate;
+        this.locationName = locationName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.roomCount = roomCount;
+        this.bedCount = bedCount;
+        this.bathRoomCount = bathRoomCount;
+        this.hasKitchen = hasKitchen;
+        this.hasWifi = hasWifi;
+        this.hasAirConditioner = hasAirConditioner;
+        this.hasHairDrier = hasHairDrier;
+    }
+
+    public Accommodation toEntity() {
+        return Accommodation.builder()
+                .name(name)
+                .description(description)
+                .limitGuestCount(limitGuestCount)
+                .pricePerDate(pricePerDate)
+                .location(new Location(locationName, latitude, longitude))
+                .facility(new Facility(roomCount, bedCount, bathRoomCount, hasKitchen, hasWifi, hasAirConditioner, hasHairDrier))
+                .build();
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/booking/domain/BookingPeriod.java
+++ b/BE/src/main/java/codesquad/airbnb/booking/domain/BookingPeriod.java
@@ -32,7 +32,11 @@ public class BookingPeriod {
 
     private static void validateDates(LocalDate checkinDate, LocalDate checkoutDate) {
         if (!checkinDate.isBefore(checkoutDate)) {
-            throw new InvalidPeriodException();
+            throw new InvalidPeriodException("체크인 날짜는 체크아웃 날짜 이전이여야 합니다.");
+        }
+
+        if (checkinDate.isBefore(LocalDate.now())) {
+            throw new InvalidPeriodException("오늘 이전의 날짜로 예약할 수 없습니다.");
         }
     }
 

--- a/BE/src/main/java/codesquad/airbnb/booking/domain/BookingPeriod.java
+++ b/BE/src/main/java/codesquad/airbnb/booking/domain/BookingPeriod.java
@@ -1,5 +1,6 @@
 package codesquad.airbnb.booking.domain;
 
+import codesquad.airbnb.exception.InvalidPeriodException;
 import lombok.*;
 
 import javax.persistence.Column;
@@ -19,10 +20,20 @@ public class BookingPeriod {
     @Column(name = "check_out_date")
     private LocalDate checkoutDate;
 
-    @Builder(access = AccessLevel.PUBLIC)
     private BookingPeriod(LocalDate checkinDate, LocalDate checkoutDate) {
         this.checkinDate = checkinDate;
         this.checkoutDate = checkoutDate;
+    }
+
+    public static BookingPeriod between(LocalDate checkinDate, LocalDate checkoutDate) {
+        validateDates(checkinDate, checkoutDate);
+        return new BookingPeriod(checkinDate, checkoutDate);
+    }
+
+    private static void validateDates(LocalDate checkinDate, LocalDate checkoutDate) {
+        if (!checkinDate.isBefore(checkoutDate)) {
+            throw new InvalidPeriodException();
+        }
     }
 
     public long betweenDays() {

--- a/BE/src/main/java/codesquad/airbnb/booking/domain/BookingPeriod.java
+++ b/BE/src/main/java/codesquad/airbnb/booking/domain/BookingPeriod.java
@@ -44,4 +44,13 @@ public class BookingPeriod {
         return ChronoUnit.WEEKS.between(checkinDate, checkoutDate);
     }
 
+    public boolean hasCommonDate(BookingPeriod otherPeriod) {
+        LocalDate otherCheckInDate = otherPeriod.checkinDate;
+        LocalDate otherCheckOutDate = otherPeriod.checkoutDate;
+
+        if (otherCheckInDate.isAfter(checkoutDate) || otherCheckOutDate.isBefore(checkinDate)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/BE/src/main/java/codesquad/airbnb/exception/AccommodationNotFoundException.java
+++ b/BE/src/main/java/codesquad/airbnb/exception/AccommodationNotFoundException.java
@@ -1,0 +1,10 @@
+package codesquad.airbnb.exception;
+
+public class AccommodationNotFoundException extends RuntimeException {
+
+    private static final String EXCEPTION_MESSAGE = "조건에 부합하는 숙소를 찾지 못 했습니다.";
+
+    public AccommodationNotFoundException() {
+        super(EXCEPTION_MESSAGE);
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/exception/DuplicateGitHubIdException.java
+++ b/BE/src/main/java/codesquad/airbnb/exception/DuplicateGitHubIdException.java
@@ -1,0 +1,10 @@
+package codesquad.airbnb.exception;
+
+public class DuplicateGitHubIdException extends RuntimeException {
+
+    private static final String EXCEPTION_MESSAGE = "중복되는 등록 gitHub Id가 존재합니다.";
+
+    public DuplicateGitHubIdException() {
+        super(EXCEPTION_MESSAGE);
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/exception/DuplicateMemberNameException.java
+++ b/BE/src/main/java/codesquad/airbnb/exception/DuplicateMemberNameException.java
@@ -1,0 +1,10 @@
+package codesquad.airbnb.exception;
+
+public class DuplicateMemberNameException extends RuntimeException {
+
+    private static final String EXCEPTION_MESSAGE = "중복되는 회원명이 존재합니다.";
+
+    public DuplicateMemberNameException() {
+        super(EXCEPTION_MESSAGE);
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/exception/InvalidPeriodException.java
+++ b/BE/src/main/java/codesquad/airbnb/exception/InvalidPeriodException.java
@@ -1,0 +1,10 @@
+package codesquad.airbnb.exception;
+
+public class InvalidPeriodException extends RuntimeException {
+
+    private static final String EXCEPTION_MESSAGE = "체크인 날짜는 체크아웃 날짜보다 앞서야합니다.";
+
+    public InvalidPeriodException() {
+        super(EXCEPTION_MESSAGE);
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/exception/InvalidPeriodException.java
+++ b/BE/src/main/java/codesquad/airbnb/exception/InvalidPeriodException.java
@@ -2,9 +2,7 @@ package codesquad.airbnb.exception;
 
 public class InvalidPeriodException extends RuntimeException {
 
-    private static final String EXCEPTION_MESSAGE = "체크인 날짜는 체크아웃 날짜보다 앞서야합니다.";
-
-    public InvalidPeriodException() {
-        super(EXCEPTION_MESSAGE);
+    public InvalidPeriodException(String message) {
+        super(message);
     }
 }

--- a/BE/src/main/java/codesquad/airbnb/exception/MemberNotFoundException.java
+++ b/BE/src/main/java/codesquad/airbnb/exception/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package codesquad.airbnb.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+
+    private static final String EXCEPTION_MESSAGE = "조건에 부합하는 회원을 찾지 못 했습니다.";
+
+    public MemberNotFoundException() {
+        super(EXCEPTION_MESSAGE);
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/member/domain/Member.java
+++ b/BE/src/main/java/codesquad/airbnb/member/domain/Member.java
@@ -1,8 +1,6 @@
 package codesquad.airbnb.member.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -10,6 +8,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
+@ToString(of = {"id", "gitHubId", "name"})
 public class Member {
 
     @Id
@@ -23,7 +22,8 @@ public class Member {
     @Column(name = "name", unique = true)
     private String name;
 
-    public Member(String gitHubId, String name) {
+    @Builder(access = AccessLevel.PUBLIC)
+    private Member(String gitHubId, String name) {
         this.gitHubId = gitHubId;
         this.name = name;
     }

--- a/BE/src/main/java/codesquad/airbnb/member/repository/MemberRepository.java
+++ b/BE/src/main/java/codesquad/airbnb/member/repository/MemberRepository.java
@@ -3,6 +3,10 @@ package codesquad.airbnb.member.repository;
 import codesquad.airbnb.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByName(String name);
+    Optional<Member> findByGitHubId(String gitHubId);
 }

--- a/BE/src/main/java/codesquad/airbnb/member/service/MemberCommandService.java
+++ b/BE/src/main/java/codesquad/airbnb/member/service/MemberCommandService.java
@@ -1,15 +1,46 @@
 package codesquad.airbnb.member.service;
 
+import codesquad.airbnb.exception.DuplicateGitHubIdException;
+import codesquad.airbnb.exception.DuplicateMemberNameException;
+import codesquad.airbnb.member.domain.Member;
 import codesquad.airbnb.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
+
+    public Long join(Member member) {
+        validateDuplicateMember(member);
+        memberRepository.save(member);
+        log.info("join Member = {}", member);
+        return member.getId();
+    }
+
+    private void validateDuplicateMember(Member member) {
+        validateDuplicateMemberName(member.getName());
+        validateDuplicateGitHubId(member.getGitHubId());
+    }
+
+    private void validateDuplicateMemberName(String memberName) {
+        memberRepository.findByName(memberName)
+                .ifPresent(duplicateMember -> {
+                    throw new DuplicateMemberNameException();
+                });
+    }
+
+    private void validateDuplicateGitHubId(String gitHubId) {
+        memberRepository.findByGitHubId(gitHubId)
+                .ifPresent(duplicateMember -> {
+                    throw new DuplicateGitHubIdException();
+                });
+    }
 
 }

--- a/BE/src/main/java/codesquad/airbnb/member/service/MemberQueryService.java
+++ b/BE/src/main/java/codesquad/airbnb/member/service/MemberQueryService.java
@@ -1,5 +1,7 @@
 package codesquad.airbnb.member.service;
 
+import codesquad.airbnb.exception.MemberNotFoundException;
+import codesquad.airbnb.member.domain.Member;
 import codesquad.airbnb.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,5 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberQueryService {
 
     private final MemberRepository memberRepository;
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new MemberNotFoundException());
+    }
 
 }

--- a/BE/src/main/java/codesquad/airbnb/member/web/MemberController.java
+++ b/BE/src/main/java/codesquad/airbnb/member/web/MemberController.java
@@ -1,11 +1,16 @@
 package codesquad.airbnb.member.web;
 
+import codesquad.airbnb.member.domain.Member;
 import codesquad.airbnb.member.service.MemberCommandService;
 import codesquad.airbnb.member.service.MemberQueryService;
+import codesquad.airbnb.member.web.dto.MemberDetailResponse;
+import codesquad.airbnb.member.web.dto.MemberJoinRequest;
+import codesquad.airbnb.member.web.dto.MemberJoinResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
@@ -13,5 +18,20 @@ public class MemberController {
 
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
+
+    @PostMapping
+    public MemberJoinResponse joinMember(@RequestBody MemberJoinRequest memberJoinRequest) {
+        log.info("Member Join Request = {}", memberJoinRequest);
+        Member member = memberJoinRequest.toEntity();
+        Long memberId = memberCommandService.join(member);
+
+        return new MemberJoinResponse(memberId);
+    }
+
+    @GetMapping("/{id}")
+    public MemberDetailResponse memberDetail(@PathVariable Long id) {
+        Member findMember = memberQueryService.findById(id);
+        return MemberDetailResponse.create(findMember);
+    }
 
 }

--- a/BE/src/main/java/codesquad/airbnb/member/web/dto/MemberDetailResponse.java
+++ b/BE/src/main/java/codesquad/airbnb/member/web/dto/MemberDetailResponse.java
@@ -1,0 +1,29 @@
+package codesquad.airbnb.member.web.dto;
+
+import codesquad.airbnb.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberDetailResponse {
+
+    private Long memberId;
+    private String memberName;
+    private String gitHubId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberDetailResponse(Long memberId, String memberName, String gitHubId) {
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.gitHubId = gitHubId;
+    }
+
+    public static MemberDetailResponse create(Member member) {
+        return MemberDetailResponse.builder()
+                .memberId(member.getId())
+                .memberName(member.getName())
+                .gitHubId(member.getGitHubId())
+                .build();
+    }
+}

--- a/BE/src/main/java/codesquad/airbnb/member/web/dto/MemberJoinRequest.java
+++ b/BE/src/main/java/codesquad/airbnb/member/web/dto/MemberJoinRequest.java
@@ -1,0 +1,27 @@
+package codesquad.airbnb.member.web.dto;
+
+import codesquad.airbnb.member.domain.Member;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(of = {"gitHubId", "name"})
+public class MemberJoinRequest {
+
+    private String gitHubId;
+    private String name;
+
+    @Builder(access = AccessLevel.PUBLIC)
+    private MemberJoinRequest(String gitHubId, String name) {
+        this.gitHubId = gitHubId;
+        this.name = name;
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .gitHubId(gitHubId)
+                .name(name)
+                .build();
+    }
+
+}

--- a/BE/src/main/java/codesquad/airbnb/member/web/dto/MemberJoinResponse.java
+++ b/BE/src/main/java/codesquad/airbnb/member/web/dto/MemberJoinResponse.java
@@ -1,0 +1,13 @@
+package codesquad.airbnb.member.web.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberJoinResponse {
+
+    private Long memberId;
+
+    public MemberJoinResponse(Long memberId) {
+        this.memberId = memberId;
+    }
+}

--- a/BE/src/test/java/codesquad/airbnb/booking/domain/BookingPeriodTest.java
+++ b/BE/src/test/java/codesquad/airbnb/booking/domain/BookingPeriodTest.java
@@ -1,0 +1,124 @@
+package codesquad.airbnb.booking.domain;
+
+import codesquad.airbnb.exception.InvalidPeriodException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("BookingPeriod의")
+class BookingPeriodTest {
+
+    @Test
+    @DisplayName("between 메서드는 체크인, 체크아웃 날짜를 상태로 갖는 BookingPeriod를 생성한다.")
+    public void between_Success_Test() {
+        //given
+        LocalDate checkinDate = LocalDate.now().plusDays(1);
+        LocalDate checkoutDate = LocalDate.now().plusDays(2);
+
+        //when
+        BookingPeriod period = BookingPeriod.between(checkinDate, checkoutDate);
+
+        //then
+        assertThat(period.getCheckinDate()).isEqualTo(checkinDate);
+        assertThat(period.getCheckoutDate()).isEqualTo(checkoutDate);
+    }
+
+    @Test
+    @DisplayName("between 메서드는 체크인, 체크아웃 날짜의 전후관계의 모순이 있으면 예외를 발생시킨다.")
+    public void between_Test_Failure_When_Checkin_is_after_CheckOut() {
+        //given
+        LocalDate checkinDate = LocalDate.now().plusDays(2);
+        LocalDate checkoutDate = LocalDate.now().plusDays(1);
+
+        //when & Then
+        assertThatThrownBy(() -> BookingPeriod.between(checkinDate, checkoutDate))
+                .isInstanceOf(InvalidPeriodException.class);
+    }
+
+    @Test
+    @DisplayName("between 메서드는 오늘 이전의 날짜를 인자로 하여 호출 시, 예외를 발생시킨다.")
+    public void between_Test_Failure_When_Checkin_is_before_Now() {
+        //given
+        LocalDate checkinDate = LocalDate.now().minusDays(1);
+        LocalDate checkoutDate = LocalDate.now().plusDays(2);
+
+        //when & Then
+        assertThatThrownBy(() -> BookingPeriod.between(checkinDate, checkoutDate))
+                .isInstanceOf(InvalidPeriodException.class);
+    }
+
+    @Test
+    @DisplayName("betweenDays 메서드는 체크인,체크아웃 날짜의 일차를 반환한다.")
+    public void betweenDaysTest() {
+        //given
+        LocalDate checkinDate = LocalDate.now().plusDays(1);
+        LocalDate checkoutDate = LocalDate.now().plusDays(5);
+        BookingPeriod bookingPeriod = BookingPeriod.between(checkinDate, checkoutDate);
+
+        //when
+        long betweenDays = bookingPeriod.betweenDays();
+
+        //then
+        assertThat(betweenDays).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("betweenWeeks 메서드는 체크인,체크아웃 날짜의 주차를 반환한다.")
+    public void betweenWeeksTest() {
+        //given
+        LocalDate checkinDate = LocalDate.now().plusDays(1);
+        LocalDate checkoutDate = LocalDate.now().plusDays(18);
+        BookingPeriod bookingPeriod = BookingPeriod.between(checkinDate, checkoutDate);
+
+        //when
+        long betweenDays = bookingPeriod.betweenWeeks();
+
+        //then
+        assertThat(betweenDays).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("hasCommonDate는 다른 BookingPeriod와 겹치는 날짜가 있을 경우 true를 반환한다.")
+    public void hasCommonDate_True_Test() {
+        //given
+        LocalDate checkinDate1 = LocalDate.now().plusDays(1);
+        LocalDate checkoutDate1 = LocalDate.now().plusDays(2);
+        BookingPeriod bookingPeriod1 = BookingPeriod.between(checkinDate1,checkoutDate1);
+
+        //given
+        LocalDate checkinDate2 = LocalDate.now().plusDays(2);
+        LocalDate checkoutDate2 = LocalDate.now().plusDays(3);
+        BookingPeriod bookingPeriod2 = BookingPeriod.between(checkinDate2,checkoutDate2);
+
+        //when
+        boolean hasCommonDate = bookingPeriod1.hasCommonDate(bookingPeriod2);
+
+        //then
+        assertThat(hasCommonDate).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasCommonDate는 다른 BookingPeriod와 겹치는 날짜가 없을 경우 false를 반환한다.")
+    public void hasCommonDate_False_Test() {
+        //given
+        LocalDate checkinDate1 = LocalDate.now().plusDays(1);
+        LocalDate checkoutDate1 = LocalDate.now().plusDays(2);
+        BookingPeriod bookingPeriod1 = BookingPeriod.between(checkinDate1,checkoutDate1);
+
+        //given
+        LocalDate checkinDate2 = LocalDate.now().plusDays(3);
+        LocalDate checkoutDate2 = LocalDate.now().plusDays(4);
+        BookingPeriod bookingPeriod2 = BookingPeriod.between(checkinDate2,checkoutDate2);
+
+        //when
+        boolean hasCommonDate = bookingPeriod1.hasCommonDate(bookingPeriod2);
+
+        //then
+        assertThat(hasCommonDate).isFalse();
+    }
+
+}


### PR DESCRIPTION
## [Team23 땃쥐] airbnb 4차

안녕하세요, 로치! Team 23의 땃쥐입니다. 4차 PR드립니다.

---

## 고민사항
```java
    public Long create(Long memberId, Long accommodationId, BookingPeriod bookingPeriod, BookingGuests bookingGuests) {
        Member member = findMember(memberId);
        Accommodation accommodation = findAccommodation(accommodationId);

        //TODO : BookingGuests가 Accommodation에서 정해준 limitGuestCount를 넘어서는지 확인

        //Todo : 기간이 겹치는 예약이 존재하는지 확인, 또는 과거 시점을 예약할 경우도 예외 발생. 이때 겹치는 예약이 존재하면 예외 발생
        // 고려할 점 : 해당 숙소를 조회하고 연관된 Booking을 모두 땡겨오기엔 데이터베이스에서 가져오는 데이터양이 불필요하게 많아진다.
        // 객체지향적인 관점에서는 Accommodation이 가지고 있는 예약들에 내부적으로 접근해서 조회하고 그들에게 물어서, 예약 가능 여부를 확인하는게 더 좋긴 한데
        // 이렇게 해버리면 비용이 너무 크다.. DB에서 겹치는 일정을 가진 Booking이 있는지 조회하는 것이 좀 더 비용이 저렴할 것 같다.

        Booking booking = Booking.create(member, accommodation, bookingPeriod, bookingGuests);
        bookingRepository.save(booking);
        return booking.getId();
    }
```
- '예약'을 할 때는 고려해야할 것이 있습니다.
- 어떤 숙소에 이미 예약되어 있는 기간에 겹치는 예약 요청이 올 경우 적절한 예외를 던져야합니다. 생성 시 `Booking.create(member, accommodation, bookingPeriod, bookingGuests)`메서드를 호출할 때, Booking은 accommodation에게 이 날짜와 겹치는 예약이 존재하는지, 인원수 제한에 문제되는지 물어보고 예약을 생성해도 될지 판단할 수 있을 것입니다. 하지만 이 방식대로면 그 숙소에 연관관계로 맵핑된 예약(Booking)들을 동적로딩을 통해 DB에서 **전부** 긁어온 다음에 그 안에서 적절한 필터링을 해야합니다. 이 경우 매우 DB에서 가져오는 데이터의 양이 많아질 것입니다.
- 현재 계획은 Booking을 생성하기 전에 DB에서 겹치는 일정의 Booking들을 한번 또 질의해서 찾아오고, 겹치는 일정이 한개라도 존재할 경우 예외를 던지는 코드를 명시적으로 Service단에 작성하는 것입니다. 이렇게 할 경우 DB에서 가져오는 데이터의 양이 줄어들 것입니다. 근데 이 방식대로면, Booking을 생성해도 될지 판단하는 로직을 Booking 스스로가 지지 못 하는 문제가 발생합니다. 어느쪽이 더 좋은가 약간 애매하고 이 부분을 고민하다가 커밋을 작성하지 못 했습니다. ㅜㅜ
