### PR TITLE
[team-2][Miller] 가격 범위 조회 기능 추가 및 PR 리뷰 반영

### DIFF
--- a/backend/src/main/java/com/codesquad/airbnb/auth/JwtFactory.java
+++ b/backend/src/main/java/com/codesquad/airbnb/auth/JwtFactory.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class JwtFactory {
         return Jwts.builder()
             .setHeader(createJwtHeader())
             .setClaims(createJwtClaims(member))
-            .setExpiration(new Date(System.currentTimeMillis() + expiredTime * 1000L))
+            .setExpiration(Date.from(Instant.now().plusSeconds(expiredTime)))
             .signWith(key, SignatureAlgorithm.HS256)
             .compact();
     }

--- a/backend/src/main/java/com/codesquad/airbnb/auth/JwtFilter.java
+++ b/backend/src/main/java/com/codesquad/airbnb/auth/JwtFilter.java
@@ -65,7 +65,8 @@ public class JwtFilter implements Filter {
             if (authorization == null || !authorization.startsWith(BEARER)) {
                 throw new NotFoundException(ErrorCode.TOKEN_NOT_FOUND);
             }
-            String token = authorization.substring(BEARER.length());
+
+            String token = getToken(authorization);
 
             // JWT 를 사이닝 키와 만료 날짜를 비교해 검증
             Claims claims = Jwts.parserBuilder()
@@ -109,6 +110,15 @@ public class JwtFilter implements Filter {
         }
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(object);
+    }
+
+    private String getToken(String authorization) {
+        String[] split = authorization.split(" ");
+
+        if (split.length != 2) {
+            throw new NotFoundException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+        return split[1];
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/auth/controller/GithubAuthController.java
+++ b/backend/src/main/java/com/codesquad/airbnb/auth/controller/GithubAuthController.java
@@ -7,6 +7,8 @@ import com.codesquad.airbnb.auth.domain.GithubToken;
 import com.codesquad.airbnb.auth.domain.GithubUser;
 import com.codesquad.airbnb.auth.domain.OAuthProperties;
 import com.codesquad.airbnb.core.member.Member;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Api(tags = "Github OAuth API")
 @RestController
 @RequestMapping("/auth/github")
 public class GithubAuthController extends AbstractAuthController {

--- a/backend/src/main/java/com/codesquad/airbnb/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/codesquad/airbnb/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.codesquad.airbnb.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
+            .allowedHeaders("*")
+            .maxAge(3600);
+    }
+
+}

--- a/backend/src/main/java/com/codesquad/airbnb/core/charge/ChargeBill.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/charge/ChargeBill.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ChargeBill {
 
+    private static final int DEFAULT_DISCOUNT_PRICE = 0;
+
     private int nights;
     private int lodgingPrice;
     private int cleaningPrice;
@@ -30,7 +32,7 @@ public class ChargeBill {
         return discounts.stream()
             .map(DiscountBill::getDiscountPrice)
             .reduce(Integer::sum)
-            .orElse(0);
+            .orElse(DEFAULT_DISCOUNT_PRICE);
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/charge/ChargeManager.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/charge/ChargeManager.java
@@ -8,6 +8,7 @@ import com.codesquad.airbnb.core.room.entity.Room;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -44,14 +45,12 @@ public class ChargeManager {
         return (int) (room.getPrice().getLodging() * TAX_COMMISSION_RATE / 100);
     }
 
-    private List<DiscountBill> createDiscounts(Room room, StayDate stayDate,
-        GuestGroup guestGroup) {
+    private List<DiscountBill> createDiscounts(Room room, StayDate stayDate, GuestGroup guestGroup) {
         List<DiscountBill> discountBills = new ArrayList<>();
 
         for (DiscountPolicy policy : discountPolicies) {
-            if (policy.canExecute(stayDate, guestGroup)) {
-                discountBills.add(policy.execute(room, stayDate, guestGroup));
-            }
+            Optional<DiscountBill> bill = policy.execute(room, stayDate, guestGroup);
+            bill.ifPresent(discountBills::add);
         }
         return discountBills;
     }

--- a/backend/src/main/java/com/codesquad/airbnb/core/charge/discount/DiscountPolicy.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/charge/discount/DiscountPolicy.java
@@ -3,11 +3,12 @@ package com.codesquad.airbnb.core.charge.discount;
 import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.StayDate;
 import com.codesquad.airbnb.core.room.entity.Room;
+import java.util.Optional;
 
 public interface DiscountPolicy {
 
     boolean canExecute(StayDate stayDate, GuestGroup guestGroup);
 
-    DiscountBill execute(Room room, StayDate stayDate, GuestGroup guestGroup);
+    Optional<DiscountBill> execute(Room room, StayDate stayDate, GuestGroup guestGroup);
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/charge/discount/WeeklyDiscountPolicy.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/charge/discount/WeeklyDiscountPolicy.java
@@ -4,6 +4,7 @@ import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.StayDate;
 import com.codesquad.airbnb.core.room.entity.Room;
 import java.time.Duration;
+import java.util.Optional;
 
 public class WeeklyDiscountPolicy implements DiscountPolicy {
 
@@ -21,16 +22,21 @@ public class WeeklyDiscountPolicy implements DiscountPolicy {
     }
 
     @Override
-    public DiscountBill execute(Room room, StayDate stayDate, GuestGroup guestGroup) {
+    public Optional<DiscountBill> execute(Room room, StayDate stayDate, GuestGroup guestGroup) {
+        if (canExecute(stayDate, guestGroup)) {
+            return Optional.empty();
+        }
+
         Duration duration = Duration.between(
             stayDate.getCheckinDate().atStartOfDay(),
             stayDate.getCheckoutDate().atStartOfDay()
         );
         int lodgingPrice = room.getPrice().getLodging();
 
-        return new DiscountBill(
+        DiscountBill bill = new DiscountBill(
             DISCOUNT_PERCENTAGE + "% " + NAME,
             (int) (lodgingPrice * duration.toDays() * DISCOUNT_PERCENTAGE / 100)
         );
+        return Optional.of(bill);
     }
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/common/embeddable/GuestGroup.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/common/embeddable/GuestGroup.java
@@ -2,6 +2,7 @@ package com.codesquad.airbnb.core.common.embeddable;
 
 import com.codesquad.airbnb.exception.ErrorCode;
 import com.codesquad.airbnb.exception.unchecked.NotAvailableException;
+import java.util.Objects;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Embeddable;
@@ -22,7 +23,9 @@ public class GuestGroup {
     private Integer numberInfant;
 
     public boolean isNull() {
-        return numberAdult == null && numberChild == null && numberInfant == null;
+        return Objects.isNull(numberAdult) &&
+            Objects.isNull(numberChild) &&
+            Objects.isNull(numberInfant);
     }
 
     public int getNumberGuest() {

--- a/backend/src/main/java/com/codesquad/airbnb/core/common/embeddable/Location.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/common/embeddable/Location.java
@@ -36,7 +36,7 @@ public class Location {
     }
 
     public boolean isNull() {
-        return longitude == null && latitude == null;
+        return Objects.isNull(longitude) || Objects.isNull(latitude);
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/common/embeddable/StayDate.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/common/embeddable/StayDate.java
@@ -1,6 +1,7 @@
 package com.codesquad.airbnb.core.common.embeddable;
 
 import java.time.LocalDate;
+import java.util.Objects;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Embeddable;
@@ -18,8 +19,7 @@ public class StayDate {
     private LocalDate checkoutDate;
 
     public StayDate(LocalDate checkinDate, LocalDate checkoutDate) {
-        if (checkinDate != null && checkoutDate != null &&
-            (checkinDate.isEqual(checkoutDate) || checkinDate.isAfter(checkoutDate))) {
+        if (!isNull() && (checkinDate.isEqual(checkoutDate) || checkinDate.isAfter(checkoutDate))) {
             throw new IllegalArgumentException("체크인 날짜가 체크아웃 날짜와 같거나 늦을 수 없습니다.");
         }
 
@@ -28,7 +28,7 @@ public class StayDate {
     }
 
     public boolean isNull() {
-        return checkinDate == null && checkoutDate == null;
+        return Objects.isNull(checkinDate) || Objects.isNull(checkoutDate);
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/district/DistrictController.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/district/DistrictController.java
@@ -31,7 +31,7 @@ public class DistrictController {
         value = "주변의 인기있는 여행지 조회",
         notes = "사용자의 현재 위치를 바탕으로 특정 반경 이내의 인기있는 여행지 목록을 반환한다."
     )
-    @GetMapping("/nearby")
+    @GetMapping
     public List<DistrictResponse> getPopularDistricts(
         @ApiParam(value = "사용자 현재 위치의 경도", required = true)
         @RequestParam("longitude") Double longitude,

--- a/backend/src/main/java/com/codesquad/airbnb/core/reservation/repository/ReservationRepositoryCustom.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/reservation/repository/ReservationRepositoryCustom.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface ReservationRepositoryCustom {
 
-    List<Reservation> findOverlappedReservations(int roomId, StayDate stayDate);
+    List<Reservation> existsOverlappedReservation(int roomId, StayDate stayDate);
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/reservation/repository/ReservationRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/reservation/repository/ReservationRepositoryCustomImpl.java
@@ -16,7 +16,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Reservation> findOverlappedReservations(int roomId, StayDate stayDate) {
+    public List<Reservation> existsOverlappedReservation(int roomId, StayDate stayDate) {
         return queryFactory.selectFrom(reservation)
             .leftJoin(reservation.room, room)
             .where(room.id.eq(roomId),

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/RoomController.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/RoomController.java
@@ -4,11 +4,12 @@ import com.codesquad.airbnb.core.charge.ChargeBill;
 import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.Location;
 import com.codesquad.airbnb.core.common.embeddable.StayDate;
+import com.codesquad.airbnb.core.room.domain.PriceRange;
+import com.codesquad.airbnb.core.room.domain.Radius;
 import com.codesquad.airbnb.core.room.dto.request.ChargeRequest;
 import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition;
-import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition.PriceRange;
-import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition.Radius;
 import com.codesquad.airbnb.core.room.dto.request.RoomSearchRequest;
+import com.codesquad.airbnb.core.room.dto.response.PriceRangeResponse;
 import com.codesquad.airbnb.core.room.dto.response.RoomDetailResponse;
 import com.codesquad.airbnb.core.room.dto.response.RoomSearchResponse;
 import io.swagger.annotations.Api;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api(tags = "Room API")
@@ -48,13 +50,13 @@ public class RoomController {
                     request.getNumChild(),
                     request.getNumInfant()
                 ),
-                new PriceRange(
-                    request.getMinPrice(),
-                    request.getMaxPrice()
-                ),
                 new StayDate(
                     request.getCheckIn(),
                     request.getCheckOut()
+                ),
+                new PriceRange(
+                    request.getMinPrice(),
+                    request.getMaxPrice()
                 )
             )
         );
@@ -87,6 +89,35 @@ public class RoomController {
                 request.getNumChild(),
                 request.getNumInfant())
         );
+    }
+
+    @ApiOperation(value = "숙소 가격 범위 조회", notes = "숙소의 가격 범위를 조회한다.")
+    @GetMapping("/prices")
+    public PriceRangeResponse showPriceRange(
+        @Valid RoomSearchRequest request,
+        @RequestParam(value = "interval", defaultValue = "1000", required = false) Integer interval
+    ) {
+        return roomService.showPriceRange(
+            new RoomSearCondition(
+                new Location(
+                    request.getLongitude(),
+                    request.getLatitude()
+                ),
+                new Radius(
+                    request.getHorizontalRadius(),
+                    request.getVerticalRadius()
+                ),
+                new GuestGroup(
+                    request.getNumAdult(),
+                    request.getNumChild(),
+                    request.getNumInfant()
+                ),
+                new StayDate(
+                    request.getCheckIn(),
+                    request.getCheckOut()
+                )
+            ),
+            interval);
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/RoomService.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/RoomService.java
@@ -4,17 +4,22 @@ import com.codesquad.airbnb.core.charge.ChargeBill;
 import com.codesquad.airbnb.core.charge.ChargeManager;
 import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.StayDate;
-import com.codesquad.airbnb.exception.ErrorCode;
-import com.codesquad.airbnb.exception.unchecked.NotFoundException;
+import com.codesquad.airbnb.core.room.domain.PriceRange;
 import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition;
+import com.codesquad.airbnb.core.room.dto.response.PriceRangeResponse;
 import com.codesquad.airbnb.core.room.dto.response.RoomDetailResponse;
 import com.codesquad.airbnb.core.room.dto.response.RoomSearchResponse;
 import com.codesquad.airbnb.core.room.entity.Room;
 import com.codesquad.airbnb.core.room.repository.RoomRepository;
+import com.codesquad.airbnb.exception.ErrorCode;
+import com.codesquad.airbnb.exception.unchecked.NotFoundException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +28,7 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final ChargeManager chargeManager;
 
+    @Transactional(readOnly = true)
     public List<RoomSearchResponse> searchRooms(RoomSearCondition condition) {
         List<Room> rooms = roomRepository.searchWithCondition(condition);
         return rooms.stream()
@@ -30,6 +36,7 @@ public class RoomService {
             .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public RoomDetailResponse findRoom(Integer id) {
         Room room = roomRepository.findByIdWithDetailAndDistrictAndImages(id)
             .orElseThrow(() -> new NotFoundException(ErrorCode.ROOM_NOT_FOUND));
@@ -37,11 +44,32 @@ public class RoomService {
         return RoomDetailResponse.from(room);
     }
 
+    @Transactional(readOnly = true)
     public ChargeBill showCharge(Integer id, StayDate stayDate, GuestGroup guestGroup) {
         Room room = roomRepository.findById(id)
             .orElseThrow(() -> new NotFoundException(ErrorCode.ROOM_NOT_FOUND));
 
         return chargeManager.createBill(room, stayDate, guestGroup);
+    }
+
+    @Transactional(readOnly = true)
+    public PriceRangeResponse showPriceRange(RoomSearCondition condition, Integer interval) {
+
+        List<Integer> prices = roomRepository.searchPriceWithCondition(condition);
+
+        PriceRange range = new PriceRange(
+            prices.size() > 0 ? Collections.min(prices) : 0,
+            prices.size() > 0 ? Collections.max(prices) : 0
+        );
+        Map<Integer, Long> buckets = prices.stream()
+            .collect(Collectors.groupingBy(
+                price -> floorWithInterval(price, interval), Collectors.counting()));
+
+        return PriceRangeResponse.of(range, buckets);
+    }
+
+    private int floorWithInterval(Integer price, Integer interval) {
+        return (int) Math.floor((double) price / interval) * interval;
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/domain/LocationCluster.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/domain/LocationCluster.java
@@ -1,7 +1,6 @@
 package com.codesquad.airbnb.core.room.domain;
 
 import com.codesquad.airbnb.core.common.embeddable.Location;
-import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition.Radius;
 import lombok.AllArgsConstructor;
 import lombok.ToString;
 

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/domain/LocationCluster.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/domain/LocationCluster.java
@@ -9,6 +9,8 @@ import lombok.ToString;
 @ToString
 public class LocationCluster {
 
+    private static final double EARTH_RADIUS = 6371.01;
+
     private final Location north;
     private final Location south;
     private final Location east;
@@ -44,7 +46,7 @@ public class LocationCluster {
         double radianLatitude = toRadian(location.getLatitude());
         double radianLongitude = toRadian(location.getLongitude());
         double radianAngle = toRadian(direction.getBearing());
-        double distanceRadius = distance / 6371.01; // earth radius
+        double distanceRadius = distance / EARTH_RADIUS; // earth radius
 
         double newLatitude = Math.asin(sin(radianLatitude) * cos(distanceRadius) +
             cos(radianLatitude) * sin(distanceRadius) * cos(radianAngle));

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/domain/PriceRange.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/domain/PriceRange.java
@@ -1,0 +1,27 @@
+package com.codesquad.airbnb.core.room.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PriceRange {
+
+    public final Integer min;
+    public final Integer max;
+
+    @JsonIgnore
+    public boolean isNull() {
+        return Objects.isNull(min) || Objects.isNull(max);
+    }
+
+    public Integer getMin() {
+        return this.min;
+    }
+
+    public Integer getMax() {
+        return this.max;
+    }
+}

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/domain/Radius.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/domain/Radius.java
@@ -1,0 +1,22 @@
+package com.codesquad.airbnb.core.room.domain;
+
+import java.util.Objects;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class Radius {
+
+    private final Double horizontal;
+    private final Double vertical;
+
+    public Radius(Double horizontal, Double vertical) {
+        this.horizontal = Objects.isNull(horizontal) ? 1.0 : horizontal;
+        this.vertical = Objects.isNull(vertical) ? 1.0 : vertical;
+    }
+
+    public boolean isNull() {
+        return Objects.isNull(horizontal) || Objects.isNull(vertical);
+    }
+}

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/dto/request/RoomSearCondition.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/dto/request/RoomSearCondition.java
@@ -47,8 +47,8 @@ public class RoomSearCondition {
         private final Double vertical;
 
         public Radius(Double horizontal, Double vertical) {
-            this.horizontal = horizontal;
-            this.vertical = vertical;
+            this.horizontal = Objects.isNull(horizontal) ? 1.0 : horizontal;
+            this.vertical = Objects.isNull(vertical) ? 1.0 : vertical;
         }
 
         public boolean isNull() {

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/dto/request/RoomSearCondition.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/dto/request/RoomSearCondition.java
@@ -3,11 +3,14 @@ package com.codesquad.airbnb.core.room.dto.request;
 import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.Location;
 import com.codesquad.airbnb.core.common.embeddable.StayDate;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class RoomSearCondition {
 
     private Location location;
@@ -23,7 +26,7 @@ public class RoomSearCondition {
         private final Integer max;
 
         public PriceRange(Integer min, Integer max) {
-            if (min != null && max != null && min > max) {
+            if (!isNull() && min > max) {
                 throw new IllegalArgumentException("최소가격이 최대가격보다 클 수 없습니다.");
             }
 
@@ -32,20 +35,24 @@ public class RoomSearCondition {
         }
 
         public boolean isNull() {
-            return min == null && max == null;
+            return Objects.isNull(min) || Objects.isNull(max);
         }
 
     }
 
     @Getter
-    @AllArgsConstructor
     public static class Radius {
 
-        private Double horizontal;
-        private Double vertical;
+        private final Double horizontal;
+        private final Double vertical;
+
+        public Radius(Double horizontal, Double vertical) {
+            this.horizontal = horizontal;
+            this.vertical = vertical;
+        }
 
         public boolean isNull() {
-            return horizontal == null && vertical == null;
+            return Objects.isNull(horizontal) || Objects.isNull(vertical);
         }
     }
 

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/dto/request/RoomSearCondition.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/dto/request/RoomSearCondition.java
@@ -3,57 +3,23 @@ package com.codesquad.airbnb.core.room.dto.request;
 import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.Location;
 import com.codesquad.airbnb.core.common.embeddable.StayDate;
-import java.util.Objects;
+import com.codesquad.airbnb.core.room.domain.PriceRange;
+import com.codesquad.airbnb.core.room.domain.Radius;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@RequiredArgsConstructor
 @Builder
 public class RoomSearCondition {
 
-    private Location location;
-    private Radius radius;
-    private GuestGroup guestGroup;
+    private final Location location;
+    private final Radius radius;
+    private final GuestGroup guestGroup;
+    private final StayDate stayDate;
     private PriceRange priceRange;
-    private StayDate stayDate;
-
-    @Getter
-    public static class PriceRange {
-
-        private final Integer min;
-        private final Integer max;
-
-        public PriceRange(Integer min, Integer max) {
-            if (!isNull() && min > max) {
-                throw new IllegalArgumentException("최소가격이 최대가격보다 클 수 없습니다.");
-            }
-
-            this.min = min;
-            this.max = max;
-        }
-
-        public boolean isNull() {
-            return Objects.isNull(min) || Objects.isNull(max);
-        }
-
-    }
-
-    @Getter
-    public static class Radius {
-
-        private final Double horizontal;
-        private final Double vertical;
-
-        public Radius(Double horizontal, Double vertical) {
-            this.horizontal = Objects.isNull(horizontal) ? 1.0 : horizontal;
-            this.vertical = Objects.isNull(vertical) ? 1.0 : vertical;
-        }
-
-        public boolean isNull() {
-            return Objects.isNull(horizontal) || Objects.isNull(vertical);
-        }
-    }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/dto/response/PriceRangeResponse.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/dto/response/PriceRangeResponse.java
@@ -1,0 +1,19 @@
+package com.codesquad.airbnb.core.room.dto.response;
+
+import com.codesquad.airbnb.core.room.domain.PriceRange;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PriceRangeResponse {
+
+    private PriceRange range;
+    private Map<Integer, Long> buckets;
+
+    public static PriceRangeResponse of(PriceRange range, Map<Integer, Long> buckets) {
+        return new PriceRangeResponse(range, buckets);
+    }
+
+}

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/dto/response/RoomSearchResponse.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/dto/response/RoomSearchResponse.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RoomSearchResponse {
 
+    private Integer id;
     private String name;
     private String address;
     private String imagePath;
@@ -43,6 +44,7 @@ public class RoomSearchResponse {
         RoomOption roomOption = detail.getOption();
 
         return new RoomSearchResponse(
+            room.getId(),
             room.getName(),
             room.getDistrict().getAddress(),
             room.getImagePath(),

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/entity/Room.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/entity/Room.java
@@ -87,10 +87,6 @@ public class Room {
         this.review = review;
     }
 
-    public Integer getLodging() {
-        return price.getLodging();
-    }
-
     public StayTime getStayTime() {
         return detail.getStayTime();
     }

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/entity/Room.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/entity/Room.java
@@ -1,7 +1,9 @@
 package com.codesquad.airbnb.core.room.entity;
 
+import com.codesquad.airbnb.core.common.embeddable.GuestGroup;
 import com.codesquad.airbnb.core.common.embeddable.Location;
 import com.codesquad.airbnb.core.common.embeddable.ReviewStat;
+import com.codesquad.airbnb.core.common.embeddable.StayTime;
 import com.codesquad.airbnb.core.district.District;
 import com.codesquad.airbnb.core.member.Member;
 import com.codesquad.airbnb.core.reservation.Reservation;
@@ -83,6 +85,18 @@ public class Room {
         this.location = location;
         this.price = price;
         this.review = review;
+    }
+
+    public Integer getLodging() {
+        return price.getLodging();
+    }
+
+    public StayTime getStayTime() {
+        return detail.getStayTime();
+    }
+
+    public void validateGuestGroup(GuestGroup guestGroup) {
+        detail.validateGuestGroup(guestGroup);
     }
 
 }

--- a/backend/src/main/java/com/codesquad/airbnb/core/room/repository/RoomRepositoryCustom.java
+++ b/backend/src/main/java/com/codesquad/airbnb/core/room/repository/RoomRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface RoomRepositoryCustom {
 
     List<Room> searchWithCondition(RoomSearCondition condition);
 
+    List<Integer> searchPriceWithCondition(RoomSearCondition condition);
+
 }

--- a/backend/src/test/java/com/codesquad/airbnb/core/reservation/ReservationServiceTest.java
+++ b/backend/src/test/java/com/codesquad/airbnb/core/reservation/ReservationServiceTest.java
@@ -66,6 +66,7 @@ class ReservationServiceTest {
         );
 
         Member host = new Member("Miller",
+            "rxdcxdrnine",
             "https://avatars.githubusercontent.com/u/50660684?v=4",
             false,
             MemberRole.USER
@@ -92,6 +93,7 @@ class ReservationServiceTest {
         );
 
         guest = new Member(
+            "BB-choi",
             "BB-choi",
             "https://avatars.githubusercontent.com/u/78826879?v=4",
             false,

--- a/backend/src/test/java/com/codesquad/airbnb/core/room/RoomServiceTest.java
+++ b/backend/src/test/java/com/codesquad/airbnb/core/room/RoomServiceTest.java
@@ -66,12 +66,14 @@ class RoomServiceTest {
 
         Member host = new Member(
             "Miller",
+            "rxdcxdrnine",
             "https://avatars.githubusercontent.com/u/50660684?v=4",
             false,
             MemberRole.USER
         );
 
         Member guest = new Member(
+            "BB-choi",
             "BB-choi",
             "https://avatars.githubusercontent.com/u/78826879?v=4",
             false,

--- a/backend/src/test/java/com/codesquad/airbnb/core/room/RoomServiceTest.java
+++ b/backend/src/test/java/com/codesquad/airbnb/core/room/RoomServiceTest.java
@@ -15,9 +15,9 @@ import com.codesquad.airbnb.core.member.Member;
 import com.codesquad.airbnb.core.member.Member.MemberRole;
 import com.codesquad.airbnb.core.reservation.Reservation;
 import com.codesquad.airbnb.core.reservation.Reservation.ReservationState;
+import com.codesquad.airbnb.core.room.domain.PriceRange;
+import com.codesquad.airbnb.core.room.domain.Radius;
 import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition;
-import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition.PriceRange;
-import com.codesquad.airbnb.core.room.dto.request.RoomSearCondition.Radius;
 import com.codesquad.airbnb.core.room.dto.response.RoomSearchResponse;
 import com.codesquad.airbnb.core.room.entity.Room;
 import com.codesquad.airbnb.core.room.entity.Room.RoomType;
@@ -130,8 +130,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(60000, 80000),
-            new StayDate(null, null)
+            new StayDate(null, null),
+            new PriceRange(60000, 80000)
         ));
 
         // then
@@ -147,8 +147,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(7000, 80000),
-            new StayDate(LocalDate.of(2022, 5, 29), LocalDate.of(2022, 5, 31))
+            new StayDate(LocalDate.of(2022, 5, 29), LocalDate.of(2022, 5, 31)),
+            new PriceRange(7000, 80000)
         ));
 
         // then
@@ -164,8 +164,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(7000, 80000),
-            new StayDate(LocalDate.of(2022, 5, 29), LocalDate.of(2022, 5, 30))
+            new StayDate(LocalDate.of(2022, 5, 29), LocalDate.of(2022, 5, 30)),
+            new PriceRange(7000, 80000)
         ));
 
         // then
@@ -181,8 +181,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(7000, 80000),
-            new StayDate(LocalDate.of(2022, 6, 1), LocalDate.of(2022, 6, 3))
+            new StayDate(LocalDate.of(2022, 6, 1), LocalDate.of(2022, 6, 3)),
+            new PriceRange(7000, 80000)
         ));
 
         // then
@@ -198,8 +198,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(7000, 80000),
-            new StayDate(LocalDate.of(2022, 6, 2), LocalDate.of(2022, 6, 3))
+            new StayDate(LocalDate.of(2022, 6, 2), LocalDate.of(2022, 6, 3)),
+            new PriceRange(7000, 80000)
         ));
 
         // then
@@ -215,8 +215,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(7000, 80000),
-            new StayDate(LocalDate.of(2022, 5, 31), LocalDate.of(2022, 6, 1))
+            new StayDate(LocalDate.of(2022, 5, 31), LocalDate.of(2022, 6, 1)),
+            new PriceRange(7000, 80000)
         ));
 
         // then
@@ -233,8 +233,8 @@ class RoomServiceTest {
             new Location(127.0286, 37.4953),
             new Radius(1.0, 1.0),
             new GuestGroup(2, 1, 0),
-            new PriceRange(7000, 80000),
-            new StayDate(LocalDate.of(2022, 5, 29), LocalDate.of(2022, 6, 3))
+            new StayDate(LocalDate.of(2022, 5, 29), LocalDate.of(2022, 6, 3)),
+            new PriceRange(7000, 80000)
         ));
 
         // then

--- a/backend/src/test/java/com/codesquad/airbnb/core/wish/WishServiceTest.java
+++ b/backend/src/test/java/com/codesquad/airbnb/core/wish/WishServiceTest.java
@@ -52,6 +52,7 @@ class WishServiceTest {
         );
 
         Member host = new Member("Miller",
+            "rxdcxdrnine",
             "https://avatars.githubusercontent.com/u/50660684?v=4",
             false,
             MemberRole.USER
@@ -70,6 +71,7 @@ class WishServiceTest {
         );
 
         guest = new Member(
+            "BB-choi",
             "BB-choi",
             "https://avatars.githubusercontent.com/u/78826879?v=4",
             false,


### PR DESCRIPTION
안녕하세요, 프레디! 😀 3주차 1번째 PR 을 요청한 Miller 입니다.

이번주에 면접을 여러개 진행하면서 생각보다 훨씬 프로젝트에 참여하지 못한 것 같습니다..
지난 번에 주신 PR 리뷰에 따라 제가 생각할 때 필수적인 사항들은 수정했지만,
fluent API 와 같이 추가적인 사항을 구현하는데까지는 하지 않았습니다 ㅠ

지난 이틀 간의 구현 사항은 아래와 같습니다.

### 비즈니스 로직 구성
- 가격 범위 조회 기능 추가

가격 범위 조회 시 ELK 스택을 사용해보고 싶었는데, 생각보다 훨씬 복잡한 것을 깨닫고
MySQL 에서 조회하는 것으로 선회했습니다.

가격 조회 시에도 Querydsl 이 SQL 문의 `from` 절 서브쿼리를 지원하지 않는다는 점과,
예약이 있는 숙소를 필터링할 때 `join` 과 함께 `groupby` 를 숙소의 `id` 에 대해 이미 사용하고 있는 탓에
데이터베이스에서 가격 범위를 그룹핑하고 히스토그램과 같이 카운팅을 하는 로직을 SQL 에서 사용하지 못했습니다.

고민 끝에 예약 날짜, 위치와 거리, 숙소 내 인원 등의 조건으로 필터링된 숙소 목록으로부터
가격 데이터를 데이터베이스에서 조회한 뒤, 자바 내에서 스트림 API 를 활용해 가격 히스토그램을 구성하는 로직을 만들었습니다.

이외에 PR 리뷰 사항과 클라이언트의 요청에 따른 수정 사항이 있습니다!
리뷰 미리 감사드립니다!