### PR TITLE
[Team-22][BE][벅픽&Lee] 3주차 2번째 PR - Oauth, JWT를 활용한 로그인 구현 및 검색 쿼리 수정

### DIFF
--- a/.github/workflows/prod-deploy-be.yml
+++ b/.github/workflows/prod-deploy-be.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Docker Environmet Variable file
         run:
-          echo -e "AIRBNB_URL=${{secrets.AIRBNB_URL}}\nAIRBNB_USER=${{secrets.AIRBNB_USER}}\nAIRBNB_PW=${{secrets.AIRBNB_PW}}\nLOG_FILE_PATH=${{secrets.LOG_FILE_PATH}}" > ./env
+          echo -e "AIRBNB_URL=${{secrets.AIRBNB_URL}}\nAIRBNB_USER=${{secrets.AIRBNB_USER}}\nAIRBNB_PW=${{secrets.AIRBNB_PW}}\nLOG_FILE_PATH=${{secrets.LOG_FILE_PATH}}\nAUTH_SECRET=${{secrets.AUTH_SECRET}}\nJWT_SECRET=${{secrets.JWT_SECRET}}" > ./env
         working-directory: ${{ env.WORKING_DIR }}
 
       - name: Set up Docker Buildx

--- a/be/.gitignore
+++ b/be/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/src/main/resources/secret.txt

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	compileOnly 'org.springframework.boot:spring-boot-starter-webflux'
+	runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.77.Final:osx-aarch_64'
+	implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
 }
 
 tasks.named('test') {

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -22,6 +22,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/be/src/main/java/kr/codesquad/airbnb/AirbnbApplication.java
+++ b/be/src/main/java/kr/codesquad/airbnb/AirbnbApplication.java
@@ -2,7 +2,9 @@ package kr.codesquad.airbnb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 
+@ServletComponentScan
 @SpringBootApplication
 public class AirbnbApplication {
 

--- a/be/src/main/java/kr/codesquad/airbnb/configuration/FilterConfig.java
+++ b/be/src/main/java/kr/codesquad/airbnb/configuration/FilterConfig.java
@@ -1,0 +1,23 @@
+package kr.codesquad.airbnb.configuration;
+
+import javax.servlet.Filter;
+import kr.codesquad.airbnb.filter.LoginValidateFilter;
+import kr.codesquad.airbnb.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class FilterConfig implements WebMvcConfigurer {
+
+    private final TokenProvider tokenProvider;
+
+    @Bean
+    public FilterRegistrationBean<Filter> loginValidateFilter() {
+        LoginValidateFilter loginValidateFilter = new LoginValidateFilter(tokenProvider);
+        return new FilterRegistrationBean<>(loginValidateFilter);
+    }
+}

--- a/be/src/main/java/kr/codesquad/airbnb/configuration/JwtConfig.java
+++ b/be/src/main/java/kr/codesquad/airbnb/configuration/JwtConfig.java
@@ -1,0 +1,23 @@
+package kr.codesquad.airbnb.configuration;
+
+import kr.codesquad.airbnb.token.TokenProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+    @Value("${app.auth.accessTokenExpireTime}")
+    private String accessTokenExpireTime;
+
+    @Bean
+    public TokenProvider jwtProvider() {
+        return new TokenProvider(
+            jwtSecret,
+            Long.parseLong(accessTokenExpireTime)
+        );
+    }
+}

--- a/be/src/main/java/kr/codesquad/airbnb/controller/AccommodationController.java
+++ b/be/src/main/java/kr/codesquad/airbnb/controller/AccommodationController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:3000")
 @RequiredArgsConstructor
 @RequestMapping("/accommodations")
 public class AccommodationController {

--- a/be/src/main/java/kr/codesquad/airbnb/controller/JwtTokenController.java
+++ b/be/src/main/java/kr/codesquad/airbnb/controller/JwtTokenController.java
@@ -1,0 +1,52 @@
+package kr.codesquad.airbnb.controller;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+@RestController
+public class JwtTokenController {
+
+    @GetMapping("/newtoken")
+    public String makeJwtToken() {
+        Date now = new Date();
+
+        String token = Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer("fresh")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + Duration.ofMinutes(30).toMillis()))
+                .claim("id", "honux")
+                .claim("email", "db1004@gmail.com")
+                .signWith(SignatureAlgorithm.HS256, "secret")
+                .compact();
+
+        return token;
+    }
+
+    @GetMapping("/parsetoken")
+    public String parseToken(@RequestHeader Map<String, String> requestHeader) {
+        System.out.println(requestHeader.keySet());
+        if (!requestHeader.containsKey("authorization")) {
+            return "Not Authorized(Doesn't have Authorization key)";
+        }
+
+        String token = requestHeader.get("authorization");
+        if (!token.startsWith("Bearer ")) {
+            return "Not Authorized(Doesn't start with Bearer)";
+        }
+        String tokenContent = token.substring("Bearer ".length());
+
+        return Jwts.parser()
+                .setSigningKey("secret")
+                .parseClaimsJws(tokenContent)
+                .getBody().toString();
+    }
+}

--- a/be/src/main/java/kr/codesquad/airbnb/controller/OauthController.java
+++ b/be/src/main/java/kr/codesquad/airbnb/controller/OauthController.java
@@ -1,0 +1,30 @@
+package kr.codesquad.airbnb.controller;
+
+import kr.codesquad.airbnb.service.OauthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.FileNotFoundException;
+
+@RestController
+@RequestMapping("oauth")
+@RequiredArgsConstructor
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    @GetMapping("/callback")
+    public String getCallback(String code) {
+        return code;
+    }
+
+    @GetMapping("/webclient")
+    public ResponseEntity<String> sendRequestToResourceServer(@RequestParam("authCode") String authCode) throws FileNotFoundException {
+        return ResponseEntity.ok(oauthService.getJwtToken(authCode));
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/airbnb/domain/member/Member.java
+++ b/be/src/main/java/kr/codesquad/airbnb/domain/member/Member.java
@@ -1,5 +1,7 @@
 package kr.codesquad.airbnb.domain.member;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
@@ -8,6 +10,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @NoArgsConstructor
+@Getter
 @Entity
 public class Member {
 
@@ -16,4 +19,8 @@ public class Member {
     private Long id;
     private String name;
     private String refreshToken;
+
+    public Member(String name) {
+        this.name = name;
+    }
 }

--- a/be/src/main/java/kr/codesquad/airbnb/dto/SearchQueryResponseDto.java
+++ b/be/src/main/java/kr/codesquad/airbnb/dto/SearchQueryResponseDto.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SearchQueryResponseDto {
 
+    private Long id;
     private String name;
     private String imgUrl;
     private int maxPeople;
@@ -19,6 +20,7 @@ public class SearchQueryResponseDto {
 
     public static SearchQueryResponseDto of(Accommodation accommodation) {
         return SearchQueryResponseDto.builder()
+                .id(accommodation.getId())
                 .name(accommodation.getName())
                 .imgUrl(accommodation.getImgUrl())
                 .maxPeople(accommodation.getSumOfPeopleCapacity())

--- a/be/src/main/java/kr/codesquad/airbnb/filter/LoginValidateFilter.java
+++ b/be/src/main/java/kr/codesquad/airbnb/filter/LoginValidateFilter.java
@@ -1,0 +1,58 @@
+package kr.codesquad.airbnb.filter;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import kr.codesquad.airbnb.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginValidateFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_AUTHORIZATION = "authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String[] authNeededUrl = {"/accommodations/*/reservation"};
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String requestUrl = request.getRequestURI();
+
+        if (isAuthNeededUrl(requestUrl)) {
+            log.info("로그인 인증 유무 확인 로직 실행 {}", requestUrl);
+            String accessToken = getAccessToken(request);
+            if (!StringUtils.hasText(accessToken) || !tokenProvider.validateToken(accessToken)) {
+                throw new RuntimeException("로그인이 필요합니다!!");
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isAuthNeededUrl(String requestUrl) {
+        return PatternMatchUtils.simpleMatch(authNeededUrl, requestUrl);
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+
+        if (headerValue == null) {
+            return null;
+        }
+
+        if (headerValue.startsWith(TOKEN_PREFIX)) {
+            return headerValue.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/be/src/main/java/kr/codesquad/airbnb/repository/AccommodationRepository.java
+++ b/be/src/main/java/kr/codesquad/airbnb/repository/AccommodationRepository.java
@@ -24,7 +24,6 @@ public interface AccommodationRepository extends JpaRepository<Accommodation, Lo
         @Param("adultChildCount") int adultChildCount,
         @Param("infantCount") int infantCount
         );
-
     @Query(value = "SELECT fee_per_one_night FROM accommodation", nativeQuery = true)
     List<Integer> findAllprices();
 }

--- a/be/src/main/java/kr/codesquad/airbnb/repository/AccommodationRepository.java
+++ b/be/src/main/java/kr/codesquad/airbnb/repository/AccommodationRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Repository
 public interface AccommodationRepository extends JpaRepository<Accommodation, Long> {
 
-    @Query(value = "SELECT AC FROM Accommodation AS AC LEFT JOIN Reservation AS RS on AC = RS.accommodation "
+    @Query(value = "SELECT DISTINCT AC FROM Accommodation AS AC LEFT JOIN Reservation AS RS on AC = RS.accommodation "
         + "WHERE (:minPrice <= AC.feePerOneNight AND AC.feePerOneNight <= :maxPrice) AND (:adultChildCount <= AC.adultChildCapacity AND :infantCount <= AC.infantCapacity) AND "
         + "( (:checkinDate IS NULL AND :checkoutDate IS NULL) OR ( RS.checkinDate IS NULL AND RS.checkoutDate IS NULL) OR RS.checkoutDate <= :checkinDate OR :checkoutDate <= RS.checkinDate)"
     )

--- a/be/src/main/java/kr/codesquad/airbnb/service/OauthService.java
+++ b/be/src/main/java/kr/codesquad/airbnb/service/OauthService.java
@@ -1,0 +1,80 @@
+package kr.codesquad.airbnb.service;
+
+import com.google.gson.Gson;
+import kr.codesquad.airbnb.domain.member.Member;
+import kr.codesquad.airbnb.repository.MemberRepository;
+import kr.codesquad.airbnb.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    public String getJwtToken(String authCode) throws FileNotFoundException {
+        String parsedToken = getAccessToken(authCode);
+        Map<String, String> userInfo = getUserInfo(parsedToken);
+        String userName = userInfo.get("login");
+        Member savedMember = memberRepository.save(new Member(userName));
+        return tokenProvider.createAccessToken(savedMember.getName(), savedMember.getId());
+    }
+
+    private String getAccessToken(String authCode) throws FileNotFoundException {
+        String secretKey = new Scanner(new File("/Users/kylechoi/Documents/Dev/airbnb/be/src/main/resources/secret.txt")).nextLine();
+
+        WebClient getAccessTokenClient = WebClient.builder()
+                .baseUrl("https://github.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        Map<String, String> bodyValues = new HashMap<>();
+        bodyValues.put("client_id", "896365878d33e50fa28b");
+        bodyValues.put("code", authCode);
+        bodyValues.put("client_secret", secretKey);
+
+        WebClient.ResponseSpec tokenResponseSpec = getAccessTokenClient.post()
+                .uri("/login/oauth/access_token")
+                .body(Mono.just(bodyValues), Map.class)
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .ifNoneMatch("*")
+                .ifModifiedSince(ZonedDateTime.now())
+                .retrieve();
+
+        String tokenResponse = tokenResponseSpec.bodyToMono(String.class).block();
+
+        return tokenResponse.split("\"")[3];
+    }
+
+    private Map<String, String> getUserInfo(String parsedToken) {
+        WebClient getUserInfoClient = WebClient.builder()
+                .baseUrl("https://api.github.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        WebClient.ResponseSpec userInfoResponseSpec = getUserInfoClient.get()
+                .uri("/user")
+                .header("authorization", String.format("token %s", parsedToken))
+                .acceptCharset(StandardCharsets.UTF_8)
+                .retrieve();
+
+        String userInfoResponse = userInfoResponseSpec.bodyToMono(String.class).block();
+
+        return new Gson().fromJson(userInfoResponse, Map.class);
+    }
+}

--- a/be/src/main/java/kr/codesquad/airbnb/token/TokenProvider.java
+++ b/be/src/main/java/kr/codesquad/airbnb/token/TokenProvider.java
@@ -1,0 +1,67 @@
+package kr.codesquad.airbnb.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TokenProvider {
+
+    private final Key key;
+    private final long accessTokenExpireTime;
+
+    public TokenProvider(String secret, long accessTokenExpireTime) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpireTime = accessTokenExpireTime;
+    }
+
+    public String createAccessToken(String userName, String id) {
+        Date now = getCurrentTime();
+        return Jwts.builder()
+            .setIssuer(userName)
+            .setIssuedAt(now)
+            .claim("id", id)
+            .setExpiration(new Date(now.getTime() + accessTokenExpireTime))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public boolean validateToken(String token) {
+        return parseClaims(token) != null;
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        } catch (SecurityException e) {
+            log.info("⚠️Invalid JWT signature.");
+        } catch (MalformedJwtException e) {
+            log.info("⚠️Invalid JWT token.");
+        } catch (ExpiredJwtException e) {
+            // TODO : 만료된 토큰 처리
+            log.info("⚠️Expired JWT token.");
+            return e.getClaims();
+        } catch (UnsupportedJwtException e) {
+            log.info("⚠️Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.info("⚠️JWT token compact of handler are invalid.");
+        }
+        return null;
+    }
+
+    private Date getCurrentTime() {
+        return new Date();
+    }
+}

--- a/be/src/main/java/kr/codesquad/airbnb/token/TokenProvider.java
+++ b/be/src/main/java/kr/codesquad/airbnb/token/TokenProvider.java
@@ -23,15 +23,15 @@ public class TokenProvider {
         this.accessTokenExpireTime = accessTokenExpireTime;
     }
 
-    public String createAccessToken(String userName, String id) {
+    public String createAccessToken(String userName, Long id) {
         Date now = getCurrentTime();
         return Jwts.builder()
-            .setIssuer(userName)
-            .setIssuedAt(now)
-            .claim("id", id)
-            .setExpiration(new Date(now.getTime() + accessTokenExpireTime))
-            .signWith(key, SignatureAlgorithm.HS256)
-            .compact();
+                .setIssuer(userName)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpireTime))
+                .claim("id", id)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
     }
 
     public boolean validateToken(String token) {

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -2,7 +2,7 @@
 spring:
   profiles:
     active: dev-h2
-    include: local-log
+    include: oauth, jwt
 ---
 # profile group
 spring:
@@ -82,6 +82,7 @@ spring:
 logging:
   file:
     path: ${LOG_FILE_PATH}
+
 ---
 # log-group
 spring:
@@ -89,3 +90,25 @@ spring:
     group:
       local-log: "console-log, low-level-log"
       deploy-log: "file-log, high-level-log"
+
+---
+# oauth
+spring:
+  config:
+    activate:
+      on-profile: oauth
+auth:
+  secret: ${AUTH_SECRET}
+
+---
+# jwt
+spring:
+  config:
+    activate:
+      on-profile: jwt
+jwt:
+  secret: ${JWT_SECRET}
+app:
+  auth:
+    accessTokenExpireTime: 900000 # 15분
+    refreshTokenExpireTime: 604800000 # 7일


### PR DESCRIPTION
안녕하세요 `Jack`!
22조 백엔드를 맡은 `벅픽, Lee`입니다.
이번 프로젝트 마지막 PR입니다. 😢

지난 3주 동안 질문사항도 너무 친절하게 답해주시고 지금 구현에서 더 발전시켜 볼 만한 부분들을 늘 짚어주셔서
공부하는 데에 정말 큰 힘이 되었습니다. 감사드립니다!

## 구현 내역

### Oauth와 JWT를 활용한 로그인 구현
- GitHub Oauth와 JWT를 활용한 로그인 구현을 시도했습니다.
- 프론트에서 보낸 깃헙 auth code를 받아 WebClient를 활용해서 깃헙 서버에 요청을 보내 Access token을 받고, 이후 해당 access token을 깃헙 resource server에 보내 유저 정보를 가져오는 로직을 구현했습니다.
- 이후 JWT 생성과 인증 로직을 구현했는데, 현재 JWT 인증을 진행하는 과정에서 오류가 발생해 그 부분에 대해 공부하고 있습니다!
- 아직 로그인이 완벽히 구현되지는 않았지만 전반적인 프로세스를 학습하며 진행해 볼 수 있었습니다.

### LEFT JOIN 쿼리로 인한 숙소 검색결과 중복 문제 해결
- 현재 숙소 검색 로직은 Accommodation 테이블과 Reservation 테이블을 LEFT JOIN해서 해당 숙소의 예약 내역을 탐색하고, 검색 조건에 해당하는 날짜에 이미 예약이 잡힌 숙소는 제외하게 되어 있습니다.
- 이 지점에서 Reservation 테이블에 있는 특정 숙소의 예약 개수만큼 검색 결과에서 해당 숙소의 정보가 중복 표시되는 버그가 있었는데요. (A라는 숙소의 예약이 3개 있으면 검색 결과에도 A가 3번 출력됨) SELECT에 DISTINCT 키워드를 붙여 문제를 해결했습니다.

다양한 예외 상황에 대한 테스트 코드 작성에 신경쓰지 못했고, 엘라스틱 서치 등의 추가 구현사항도 구현해 보면 좋았을텐데 처음 구현하는 것들이 많다 보니 여유가 많지 않았네요ㅠㅠ
그래도 이번 프로젝트에서 공부하며 시도해 본 것들을 바탕으로 다음 프로젝트에서는 더 잘 만들 수 있도록 하겠습니다. 

다시 한 번 리뷰 감사드립니다. 좋은 주말 보내세요!-! 😀